### PR TITLE
Add cart cleanup routine

### DIFF
--- a/includes/cart/class-cart-cleanup.php
+++ b/includes/cart/class-cart-cleanup.php
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Helper for removing expired carts from the database.
+ */
+class TTA_Cart_Cleanup {
+
+    /**
+     * Delete cart rows whose expires_at is in the past.
+     */
+    public static function clean_expired_carts() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tta_carts';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$table} WHERE expires_at < %s",
+                current_time( 'mysql' )
+            )
+        );
+    }
+
+    /**
+     * Schedule the hourly cleanup event if not already scheduled.
+     */
+    public static function schedule_event() {
+        if ( ! wp_next_scheduled( 'tta_cart_cleanup_event' ) ) {
+            wp_schedule_event( time(), 'hourly', 'tta_cart_cleanup_event' );
+        }
+    }
+
+    /**
+     * Clear the scheduled cleanup on plugin deactivation.
+     */
+    public static function clear_event() {
+        wp_clear_scheduled_hook( 'tta_cart_cleanup_event' );
+    }
+
+    /**
+     * Init hooks.
+     */
+    public static function init() {
+        add_action( 'tta_checkout_complete', [ __CLASS__, 'clean_expired_carts' ] );
+        add_action( 'tta_cart_cleanup_event', [ __CLASS__, 'clean_expired_carts' ] );
+        self::schedule_event();
+    }
+}

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -106,4 +106,15 @@ class TTA_Cart {
       [ '%d' ]
     );
   }
+
+  /**
+   * Finalize checkout and trigger completion actions.
+   *
+   * This basic implementation simply empties the cart.
+   * Hooked listeners can handle ticket delivery or payment processing.
+   */
+  public function finalize_purchase() {
+    $this->empty_cart();
+    do_action( 'tta_checkout_complete', $this->cart_id );
+  }
 }

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -52,12 +52,15 @@ require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart.php';
+require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart-cleanup.php';
 
 
 
 // Activation & Deactivation
 register_activation_hook( __FILE__, array( 'TTA_DB_Setup', 'install' ) );
+register_activation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'schedule_event' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_DB_Setup', 'uninstall' ) );
+register_deactivation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'clear_event' ) );
 
 // Initialize plugin
 add_action( 'plugins_loaded', array( 'TTA_Plugin', 'init' ) );
@@ -82,6 +85,9 @@ class TTA_Plugin {
         // Notification handlers
         TTA_Email_Handler::get_instance();
         TTA_SMS_Handler::get_instance();
+
+        // Expired cart cleanup
+        TTA_Cart_Cleanup::init();
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- add `TTA_Cart_Cleanup` helper to purge expired carts
- invoke cleanup hourly via WP‑Cron and on plugin init
- remove expired carts after a checkout finishes
- introduce `finalize_purchase()` in cart class

## Testing
- `php -l includes/cart/class-cart-cleanup.php`
- `php -l includes/cart/class-cart.php`
- `php -l trying-to-adult-management-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_684c4c60a2e48320a26ab9f1f8b1803f