### PR TITLE
Add cart page template

### DIFF
--- a/assets/css/frontend/cart-page.css
+++ b/assets/css/frontend/cart-page.css
@@ -1,0 +1,24 @@
+/* assets/css/frontend/cart-page.css */
+
+.tta-cart-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+.tta-cart-table th,
+.tta-cart-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.tta-cart-checkout-button {
+  display: inline-block;
+  padding: 10px 20px;
+  background-color: #0073aa;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/includes/ajax/handlers/class-ajax-cart.php
+++ b/includes/ajax/handlers/class-ajax-cart.php
@@ -65,8 +65,8 @@ class TTA_Ajax_Cart {
             $cart->add_item( $ticket_id, $qty, $price );
         }
 
-        $cart_page_id = get_option( 'tta_cart_page_id' );
-        $cart_url     = $cart_page_id ? get_permalink( $cart_page_id ) : home_url();
+        // Always send users to the dedicated cart page
+        $cart_url = home_url( '/cart' );
 
         wp_send_json_success( [ 'cart_url' => $cart_url ] );
     }

--- a/includes/cart/class-cart-cleanup.php
+++ b/includes/cart/class-cart-cleanup.php
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Helper for removing expired carts from the database.
+ */
+class TTA_Cart_Cleanup {
+
+    /**
+     * Delete cart rows whose expires_at is in the past.
+     */
+    public static function clean_expired_carts() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tta_carts';
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$table} WHERE expires_at < %s",
+                current_time( 'mysql' )
+            )
+        );
+    }
+
+    /**
+     * Schedule the hourly cleanup event if not already scheduled.
+     */
+    public static function schedule_event() {
+        if ( ! wp_next_scheduled( 'tta_cart_cleanup_event' ) ) {
+            wp_schedule_event( time(), 'hourly', 'tta_cart_cleanup_event' );
+        }
+    }
+
+    /**
+     * Clear the scheduled cleanup on plugin deactivation.
+     */
+    public static function clear_event() {
+        wp_clear_scheduled_hook( 'tta_cart_cleanup_event' );
+    }
+
+    /**
+     * Init hooks.
+     */
+    public static function init() {
+        add_action( 'tta_checkout_complete', [ __CLASS__, 'clean_expired_carts' ] );
+        add_action( 'tta_cart_cleanup_event', [ __CLASS__, 'clean_expired_carts' ] );
+        self::schedule_event();
+    }
+}

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -106,4 +106,15 @@ class TTA_Cart {
       [ '%d' ]
     );
   }
+
+  /**
+   * Finalize checkout and trigger completion actions.
+   *
+   * This basic implementation simply empties the cart.
+   * Hooked listeners can handle ticket delivery or payment processing.
+   */
+  public function finalize_purchase() {
+    $this->empty_cart();
+    do_action( 'tta_checkout_complete', $this->cart_id );
+  }
 }

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -109,7 +109,7 @@ class TTA_Assets {
             TTA_PLUGIN_VERSION
         );
 
-        // 2) Only on our “Event Page” template, enqueue event‐page.css and cart + event JS
+        // 2) Only on our “Event Page” template, enqueue event-page.css and cart + event JS
         if ( function_exists( 'is_page_template' ) && is_page_template( 'event-page-template.php' ) ) {
             // Event page CSS
             wp_enqueue_style(
@@ -135,6 +135,33 @@ class TTA_Assets {
                 TTA_PLUGIN_VERSION,
                 true
             );
+            wp_localize_script(
+                'tta-cart-js',
+                'tta_ajax',
+                [
+                    'ajax_url' => admin_url( 'admin-ajax.php' ),
+                    'nonce'    => wp_create_nonce( 'tta_frontend_nonce' ),
+                ]
+            );
+        }
+
+        // 3) Cart Page template assets
+        if ( function_exists( 'is_page_template' ) && is_page_template( 'cart-page-template.php' ) ) {
+            wp_enqueue_style(
+                'tta-cartpage-css',
+                TTA_PLUGIN_URL . 'assets/css/frontend/cart-page.css',
+                [ 'tta-frontend-css' ],
+                TTA_PLUGIN_VERSION
+            );
+
+            wp_enqueue_script(
+                'tta-cart-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/tta-cart.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
+
             wp_localize_script(
                 'tta-cart-js',
                 'tta_ajax',

--- a/includes/frontend/templates/cart-page-template.php
+++ b/includes/frontend/templates/cart-page-template.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Template Name: Cart Page
+ *
+ * @package TTA
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+
+$cart = new TTA_Cart();
+
+if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_checkout'] ) ) {
+    $cart->finalize_purchase();
+    wp_safe_redirect( add_query_arg( 'checkout', 'done', get_permalink() ) );
+    exit;
+}
+
+$items         = $cart->get_items();
+$checkout_done = isset( $_GET['checkout'] ) && 'done' === $_GET['checkout'];
+?>
+
+<div class="wrap tta-cart-page">
+    <?php if ( $checkout_done ) : ?>
+        <p class="tta-checkout-complete">
+            <?php esc_html_e( 'Thank you for your purchase!', 'tta' ); ?>
+        </p>
+    <?php endif; ?>
+
+    <?php if ( $items ) : ?>
+        <form method="post">
+            <table class="tta-cart-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Ticket', 'tta' ); ?></th>
+                        <th><?php esc_html_e( 'Quantity', 'tta' ); ?></th>
+                        <th><?php esc_html_e( 'Price', 'tta' ); ?></th>
+                        <th><?php esc_html_e( 'Subtotal', 'tta' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php $total = 0; ?>
+                    <?php foreach ( $items as $it ) : ?>
+                        <?php $sub = $it['quantity'] * $it['price']; $total += $sub; ?>
+                        <tr>
+                            <td><?php echo esc_html( $it['ticket_name'] ); ?></td>
+                            <td><?php echo intval( $it['quantity'] ); ?></td>
+                            <td><?php echo esc_html( number_format( $it['price'], 2 ) ); ?></td>
+                            <td><?php echo esc_html( number_format( $sub, 2 ) ); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th colspan="3"><?php esc_html_e( 'Total', 'tta' ); ?></th>
+                        <td><?php echo esc_html( number_format( $total, 2 ) ); ?></td>
+                    </tr>
+                </tfoot>
+            </table>
+            <p>
+                <button class="tta-cart-checkout-button" name="tta_checkout" type="submit">
+                    <?php esc_html_e( 'Checkout', 'tta' ); ?>
+                </button>
+            </p>
+        </form>
+    <?php else : ?>
+        <p><?php esc_html_e( 'Your cart is empty.', 'tta' ); ?></p>
+    <?php endif; ?>
+</div>
+
+<?php
+get_footer();

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -52,12 +52,15 @@ require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart.php';
+require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart-cleanup.php';
 
 
 
 // Activation & Deactivation
 register_activation_hook( __FILE__, array( 'TTA_DB_Setup', 'install' ) );
+register_activation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'schedule_event' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_DB_Setup', 'uninstall' ) );
+register_deactivation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'clear_event' ) );
 
 // Initialize plugin
 add_action( 'plugins_loaded', array( 'TTA_Plugin', 'init' ) );
@@ -82,6 +85,9 @@ class TTA_Plugin {
         // Notification handlers
         TTA_Email_Handler::get_instance();
         TTA_SMS_Handler::get_instance();
+
+        // Expired cart cleanup
+        TTA_Cart_Cleanup::init();
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- create `cart-page-template.php` with basic checkout flow
- style the cart table via new `cart-page.css`
- enqueue cart assets on the cart page template

## Testing
- `php -l includes/classes/class-tta-assets.php`
- `php -l includes/frontend/templates/cart-page-template.php`
- `php -l includes/cart/class-cart-cleanup.php`
- `php -l includes/cart/class-cart.php`
- `php -l includes/ajax/handlers/class-ajax-cart.php`
- `php -l trying-to-adult-management-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_684c4c60a2e48320a26ab9f1f8b1803f