### PR TITLE
Refactor attendance limit to ticketlimit

### DIFF
--- a/includes/admin/views/tickets-edit.php
+++ b/includes/admin/views/tickets-edit.php
@@ -97,7 +97,7 @@ $tickets = $wpdb->get_results(
         </tr>
         <tr>
           <th>
-            <label for="attendancelimit_<?php echo $tid; ?>"><?php esc_html_e( 'Attendance Limit', 'tta' ); ?></label>
+            <label for="ticketlimit_<?php echo $tid; ?>"><?php esc_html_e( 'Ticket Limit', 'tta' ); ?></label>
             <span class="tta-tooltip-icon"
                   data-tooltip="<?php esc_attr_e( 'Maximum number of tickets available.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
@@ -106,9 +106,9 @@ $tickets = $wpdb->get_results(
           </th>
           <td>
             <input type="number"
-                   name="attendancelimit[<?php echo $tid; ?>]"
-                   id="attendancelimit_<?php echo $tid; ?>"
-                   value="<?php echo esc_attr( $t['attendancelimit'] ); ?>">
+                   name="ticketlimit[<?php echo $tid; ?>]"
+                   id="ticketlimit_<?php echo $tid; ?>"
+                   value="<?php echo esc_attr( $t['ticketlimit'] ); ?>">
           </td>
         </tr>
         <tr>
@@ -291,14 +291,14 @@ $tickets = $wpdb->get_results(
         </tr>
         <tr>
           <th>
-            <label><?php esc_html_e( 'Attendance Limit', 'tta' ); ?></label>
+            <label><?php esc_html_e( 'Ticket Limit', 'tta' ); ?></label>
             <span class="tta-tooltip-icon"
                   data-tooltip="<?php esc_attr_e( 'Maximum number of tickets available.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                    alt="Help">
             </span>
           </th>
-          <td><input type="number" name="new_attendancelimit[]" value="0"></td>
+          <td><input type="number" name="new_ticketlimit[]" value="10000"></td>
         </tr>
         <tr>
           <th>

--- a/includes/ajax/handlers/class-ajax-events.php
+++ b/includes/ajax/handlers/class-ajax-events.php
@@ -73,6 +73,7 @@ class TTA_Ajax_Events {
             'event_ute_id'         => $ute_id,
             'event_name'           => $event_data['name'],
             'ticket_name'          => 'General Admission',
+            'ticketlimit'          => 10000,
             'waitlist_id'          => 0,
             'baseeventcost'        => $event_data['baseeventcost'],
             'discountedmembercost' => $event_data['discountedmembercost'],

--- a/includes/ajax/handlers/class-ajax-tickets.php
+++ b/includes/ajax/handlers/class-ajax-tickets.php
@@ -71,7 +71,7 @@ class TTA_Ajax_Tickets {
 
         // 3) Grab submitted arrays for existing tickets
         $names               = $_POST['event_name']           ?? [];
-        $limits              = $_POST['attendancelimit']      ?? [];
+        $limits              = $_POST['ticketlimit']          ?? [];
         $base_costs          = $_POST['baseeventcost']        ?? [];
         $member_costs        = $_POST['discountedmembercost'] ?? [];
         $premium_costs       = $_POST['premiummembercost']    ?? [];
@@ -87,7 +87,7 @@ class TTA_Ajax_Tickets {
                 $tickets_table,
                 [
                     'ticket_name'          => $ticket_name,
-                    'attendancelimit'      => intval( $limits[ $tid ] ?? 0 ),
+                    'ticketlimit'          => intval( $limits[ $tid ] ?? 0 ),
                     'baseeventcost'        => floatval( $base_costs[ $tid ] ?? 0 ),
                     'discountedmembercost' => floatval( $member_costs[ $tid ] ?? 0 ),
                     'premiummembercost'    => floatval( $premium_costs[ $tid ] ?? 0 ),
@@ -159,7 +159,7 @@ class TTA_Ajax_Tickets {
         // 6) Insert any new tickets (and waitlists if enabled)
         if ( ! empty( $_POST['new_event_name'] ) ) {
             $new_names   = $_POST['new_event_name']            ?? [];
-            $new_limits  = $_POST['new_attendancelimit']       ?? [];
+            $new_limits  = $_POST['new_ticketlimit']          ?? [];
             $new_base    = $_POST['new_baseeventcost']         ?? [];
             $new_member  = $_POST['new_discountedmembercost']  ?? [];
             $new_prem    = $_POST['new_premiummembercost']     ?? [];
@@ -177,7 +177,7 @@ class TTA_Ajax_Tickets {
                         'event_ute_id'          => $ute,
                         'event_name'            => $event_name,
                         'ticket_name'           => $ticket_name,
-                        'attendancelimit'       => intval( $new_limits[ $i ]    ?? 0 ),
+                        'ticketlimit'           => intval( $new_limits[ $i ]    ?? 10000 ),
                         'baseeventcost'         => floatval( $new_base[ $i ]     ?? 0 ),
                         'discountedmembercost'  => floatval( $new_member[ $i ]   ?? 0 ),
                         'premiummembercost'     => floatval( $new_prem[ $i ]     ?? 0 ),

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -102,7 +102,7 @@ class TTA_DB_Setup {
             event_name             VARCHAR(255) NOT NULL,
             ticket_name            VARCHAR(255) NOT NULL,
             waitlist_id            BIGINT UNSIGNED NOT NULL,
-            attendancelimit        INT UNSIGNED NOT NULL,
+            ticketlimit            INT UNSIGNED NOT NULL DEFAULT 10000,
             baseeventcost          DECIMAL(10,2) NOT NULL,
             discountedmembercost   DECIMAL(10,2) NOT NULL,
             premiummembercost      DECIMAL(10,2) DEFAULT 0.00,

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -45,7 +45,7 @@ if ( ! $event ) {
 $tickets_table = $wpdb->prefix . 'tta_tickets';
 $tickets       = $wpdb->get_results(
     $wpdb->prepare(
-        "SELECT id, ticket_name, attendancelimit, baseeventcost, discountedmembercost, premiummembercost
+        "SELECT id, ticket_name, ticketlimit, baseeventcost, discountedmembercost, premiummembercost
          FROM {$tickets_table}
          WHERE event_ute_id = %s
          ORDER BY id ASC",
@@ -362,12 +362,12 @@ if ( $ticket_count > 1 ) {
         <h2><?php esc_html_e( 'Get Your Tickets Now', 'tta' ); ?></h2>
 
         <?php if ( $tickets ) : ?>
-          <?php foreach ( $tickets as $ticket ) : 
-            $limit      = intval( $ticket['attendancelimit'] );
+          <?php foreach ( $tickets as $ticket ) :
+            $limit      = intval( $ticket['ticketlimit'] );
             $available  = $limit > 0 ? $limit : 0;
             $avail_text = $available > 0
                 ? sprintf( esc_html__( 'Only %d Left!', 'tta' ), $available )
-                : esc_html__( '', 'tta' );
+                : esc_html__( 'Sold Out', 'tta' );
             $avail_text = '<span class="tta-fomo-remaining-styling">' . $avail_text . '</span>';
 
             // membership‐tier pricing for this row
@@ -417,7 +417,7 @@ if ( $ticket_count > 1 ) {
             type="button"
             id="tta-get-tickets"
             class="tta-button tta-button-primary"
-            <?php disabled( empty( $tickets ) || intval( $tickets[0]['attendancelimit'] ) < 1 ); ?>
+            <?php disabled( empty( $tickets ) || intval( $tickets[0]['ticketlimit'] ) < 1 ); ?>
           >
             <?php esc_html_e( 'Get Tickets', 'tta' ); ?>
           </button>


### PR DESCRIPTION
## Summary
- rename attendance limit column to `ticketlimit` with default `10000`
- update AJAX handlers and admin forms to use `ticketlimit`
- show **Sold Out** when a ticket's limit reaches zero on the event page

## Testing
- `php -l includes/class-db-setup.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685000fa04308320b961793c21f98a08