### PR TITLE
Improve expiration date validation

### DIFF
--- a/assets/js/frontend/checkout-expiration-mask.js
+++ b/assets/js/frontend/checkout-expiration-mask.js
@@ -1,12 +1,16 @@
 jQuery(function($){
   var $exp = $('#tta-card-exp');
+
+  function formatExp() {
+    var digits = $exp.val().replace(/[^0-9]/g, '').slice(0,4);
+    if ( digits.length > 2 ) {
+      digits = digits.slice(0,2) + '/' + digits.slice(2);
+    }
+    $exp.val(digits);
+  }
+
   if ( $exp.length ) {
-    $exp.on('input', function(){
-      var digits = $exp.val().replace(/[^0-9]/g, '');
-      if ( digits.length > 2 ) {
-        digits = digits.slice(0,2) + '/' + digits.slice(2,4);
-      }
-      $exp.val(digits);
-    });
+    formatExp();
+    $exp.on('input', formatExp);
   }
 });

--- a/assets/js/frontend/checkout-expiration-mask.js
+++ b/assets/js/frontend/checkout-expiration-mask.js
@@ -1,0 +1,12 @@
+jQuery(function($){
+  var $exp = $('#tta-card-exp');
+  if ( $exp.length ) {
+    $exp.on('input', function(){
+      var digits = $exp.val().replace(/[^0-9]/g, '');
+      if ( digits.length > 2 ) {
+        digits = digits.slice(0,2) + '/' + digits.slice(2,4);
+      }
+      $exp.val(digits);
+    });
+  }
+});

--- a/includes/admin/views/events-create.php
+++ b/includes/admin/views/events-create.php
@@ -13,6 +13,10 @@ if ( isset( $_GET['event_id'] ) ) {
     ), ARRAY_A );
     if ( $event ) {
         $editing = true;
+        $disc               = tta_parse_discount_data( $event['discountcode'] );
+        $event['discountcode']   = $disc['code'];
+        $event['discount_type']  = $disc['type'];
+        $event['discount_amount'] = $disc['amount'];
     }
 }
 
@@ -47,7 +51,11 @@ if ( isset( $_POST['tta_event_save'] ) && check_admin_referer(
         'attendancelimit'       => intval( $_POST['attendancelimit'] ),
         'waitlistavailable'     => sanitize_text_field( $_POST['waitlistavailable'] ),
         'refundsavailable'      => sanitize_text_field( $_POST['refundsavailable'] ),
-        'discountcode'          => sanitize_text_field( $_POST['discountcode'] ),
+        'discountcode'          => tta_build_discount_data(
+            $_POST['discountcode'] ?? '',
+            $_POST['discount_type'] ?? 'percent',
+            $_POST['discount_amount'] ?? 0
+        ),
         'url2'                  => esc_url_raw( $_POST['url2'] ),
         'url3'                  => esc_url_raw( $_POST['url3'] ),
         'url4'                  => esc_url_raw( $_POST['url4'] ),
@@ -73,6 +81,12 @@ if ( isset( $_POST['tta_event_save'] ) && check_admin_referer(
             "SELECT * FROM {$table} WHERE id = %d",
             $id
         ), ARRAY_A );
+        if ( $event ) {
+            $disc               = tta_parse_discount_data( $event['discountcode'] );
+            $event['discountcode']   = $disc['code'];
+            $event['discount_type']  = $disc['type'];
+            $event['discount_amount'] = $disc['amount'];
+        }
     }
 }
 ?>
@@ -400,6 +414,22 @@ if ( isset( $_POST['tta_event_save'] ) && check_admin_referer(
             <td>
                 <input type="text" name="discountcode" id="discountcode" class="regular-text"
                        value="<?php echo esc_attr($event['discountcode']??''); ?>">
+            </td>
+        </tr>
+        <tr>
+            <th><label for="discount_type">Discount Type</label></th>
+            <td>
+                <select name="discount_type" id="discount_type">
+                    <option value="flat" <?php selected($event['discount_type']??'percent','flat'); ?>>Flat $ Amount Off</option>
+                    <option value="percent" <?php selected($event['discount_type']??'percent','percent'); ?>>Percentage Off</option>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <th><label for="discount_amount">Discount Amount</label></th>
+            <td>
+                <input type="number" name="discount_amount" id="discount_amount" step="0.01" min="0"
+                       value="<?php echo esc_attr($event['discount_amount']??0); ?>">
             </td>
         </tr>
 

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -21,6 +21,10 @@ if ( isset( $_GET['event_id'] ) ) {
     );
     if ( $event ) {
         $editing = true;
+        $disc               = tta_parse_discount_data( $event['discountcode'] );
+        $event['discountcode']   = $disc['code'];
+        $event['discount_type']  = $disc['type'];
+        $event['discount_amount'] = $disc['amount'];
     }
 }
 ?>
@@ -425,6 +429,22 @@ if ( isset( $_GET['event_id'] ) ) {
                 <td>
                     <input type="text" name="discountcode" id="discountcode" class="regular-text"
                            value="<?php echo esc_attr( $event['discountcode'] ?? '' ); ?>">
+                </td>
+            </tr>
+            <tr>
+                <th><label for="discount_type">Discount Type</label></th>
+                <td>
+                    <select name="discount_type" id="discount_type">
+                        <option value="flat" <?php selected( $event['discount_type'] ?? 'percent', 'flat' ); ?>>Flat $ Amount Off</option>
+                        <option value="percent" <?php selected( $event['discount_type'] ?? 'percent', 'percent' ); ?>>Percentage Off</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label for="discount_amount">Discount Amount</label></th>
+                <td>
+                    <input type="number" name="discount_amount" id="discount_amount" step="0.01" min="0"
+                           value="<?php echo esc_attr( $event['discount_amount'] ?? 0 ); ?>">
                 </td>
             </tr>
 

--- a/includes/ajax/handlers/class-ajax-events.php
+++ b/includes/ajax/handlers/class-ajax-events.php
@@ -53,7 +53,11 @@ class TTA_Ajax_Events {
             'premiummembercost'    => floatval( $_POST['premiummembercost']   ?? 0 ),
             'waitlistavailable'    => $waitlist_available,
             'refundsavailable'     => sanitize_text_field( $_POST['refundsavailable']    ?? '0' ),
-            'discountcode'         => sanitize_text_field( $_POST['discountcode']        ?? '' ),
+            'discountcode'         => tta_build_discount_data(
+                $_POST['discountcode'] ?? '',
+                $_POST['discount_type'] ?? 'percent',
+                $_POST['discount_amount'] ?? 0
+            ),
             'url2'                 => esc_url_raw( $_POST['url2']                ?? '' ),
             'url3'                 => esc_url_raw( $_POST['url3']                ?? '' ),
             'url4'                 => esc_url_raw( $_POST['url4']                ?? '' ),
@@ -194,7 +198,11 @@ class TTA_Ajax_Events {
             'premiummembercost'    => floatval( $_POST['premiummembercost']    ?? 0 ),
             'waitlistavailable'    => sanitize_text_field( $_POST['waitlistavailable']   ?? '0' ),
             'refundsavailable'     => sanitize_text_field( $_POST['refundsavailable']    ?? '0' ),
-            'discountcode'         => sanitize_text_field( $_POST['discountcode']        ?? '' ),
+            'discountcode'         => tta_build_discount_data(
+                $_POST['discountcode'] ?? '',
+                $_POST['discount_type'] ?? 'percent',
+                $_POST['discount_amount'] ?? 0
+            ),
             'url2'                 => esc_url_raw( $_POST['url2']                ?? '' ),
             'url3'                 => esc_url_raw( $_POST['url3']                ?? '' ),
             'url4'                 => esc_url_raw( $_POST['url4']                ?? '' ),

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -14,7 +14,8 @@ class TTA_Cart {
     $this->carts_table = $wpdb->prefix . 'tta_carts';
     $this->items_table = $wpdb->prefix . 'tta_cart_items';
     $this->init_session();
-    $this->ensure_cart();
+    // Only load an existing cart on construct; don't create one until needed.
+    $this->ensure_cart( false );
   }
 
   protected function init_session() {
@@ -27,8 +28,8 @@ class TTA_Cart {
     $this->session_key = $_SESSION['tta_cart_session'];
   }
 
-  protected function ensure_cart() {
-    // load or create a cart row
+  protected function ensure_cart( $create = true ) {
+    // load or optionally create a cart row
     $row = $this->wpdb->get_row(
       $this->wpdb->prepare(
         "SELECT * FROM {$this->carts_table} WHERE session_key = %s",
@@ -38,7 +39,7 @@ class TTA_Cart {
     );
     if ( $row ) {
       $this->cart_id = (int)$row['id'];
-    } else {
+    } elseif ( $create ) {
       $now = current_time('mysql');
       $expires = date('Y-m-d H:i:s', strtotime('+30 minutes'));
       $this->wpdb->insert(
@@ -56,6 +57,7 @@ class TTA_Cart {
   }
 
   public function add_item( $ticket_id, $qty, $price ) {
+    $this->ensure_cart( true );
     if ( $qty <= 0 ) {
       $this->remove_item( $ticket_id );
       return;
@@ -90,6 +92,7 @@ class TTA_Cart {
   }
 
   public function update_quantity( $ticket_id, $qty ) {
+    $this->ensure_cart( true );
     if ( $qty <= 0 ) {
       $this->remove_item( $ticket_id );
     } else {
@@ -103,6 +106,7 @@ class TTA_Cart {
   }
 
   public function remove_item( $ticket_id ) {
+    $this->ensure_cart( false );
     $this->wpdb->delete(
       $this->items_table,
       [ 'cart_id' => $this->cart_id, 'ticket_id' => $ticket_id ],
@@ -111,6 +115,7 @@ class TTA_Cart {
   }
 
   public function get_items() {
+    $this->ensure_cart( false );
     return $this->wpdb->get_results(
       $this->wpdb->prepare(
           "SELECT ci.*, t.ticket_name, t.event_ute_id, e.discountcode
@@ -126,22 +131,31 @@ class TTA_Cart {
 
   public function get_total( $discount_code = '' ) {
     $total = 0;
+    $info  = null;
     foreach ( $this->get_items() as $it ) {
       $sub = $it['quantity'] * $it['price'];
-      $info = tta_parse_discount_data( $it['discountcode'] );
-      if ( $discount_code && $info['code'] && strtolower( $discount_code ) === strtolower( $info['code'] ) ) {
-        if ( 'flat' === $info['type'] ) {
-          $sub = max( 0, $sub - $info['amount'] );
-        } else {
-          $sub *= max( 0, 1 - ( $info['amount'] / 100 ) );
+      $total += $sub;
+      if ( null === $info && $discount_code ) {
+        $d = tta_parse_discount_data( $it['discountcode'] );
+        if ( $d['code'] && strtolower( $discount_code ) === strtolower( $d['code'] ) ) {
+          $info = $d;
         }
       }
-      $total += $sub;
     }
+
+    if ( $discount_code && $info ) {
+      if ( 'flat' === $info['type'] ) {
+        $total = max( 0, $total - $info['amount'] );
+      } else {
+        $total *= max( 0, 1 - ( $info['amount'] / 100 ) );
+      }
+    }
+
     return $total;
   }
 
   public function empty_cart() {
+    $this->ensure_cart( false );
     $this->wpdb->delete(
       $this->items_table,
       [ 'cart_id' => $this->cart_id ],
@@ -161,8 +175,10 @@ class TTA_Cart {
     $discount_code = $_SESSION['tta_discount_code'] ?? '';
     $items         = $this->get_items();
     $discount_total = 0;
+    $discount_info  = null;
+    $total_before   = 0;
 
-    // Decrement ticket availability and flag used discounts per item
+    // Decrement availability and locate discount info
     foreach ( $items as &$item ) {
       $wpdb->query(
         $wpdb->prepare(
@@ -173,19 +189,32 @@ class TTA_Cart {
       );
 
       $sub  = $item['quantity'] * $item['price'];
-      $info = tta_parse_discount_data( $item['discountcode'] );
-      $saved = 0;
-      if ( $discount_code && $info['code'] && strtolower( $discount_code ) === strtolower( $info['code'] ) ) {
-        if ( 'flat' === $info['type'] ) {
-          $saved = min( $sub, $info['amount'] );
-        } else {
-          $saved = $sub * ( $info['amount'] / 100 );
+      $total_before += $sub;
+
+      if ( null === $discount_info && $discount_code ) {
+        $info = tta_parse_discount_data( $item['discountcode'] );
+        if ( $info['code'] && strtolower( $discount_code ) === strtolower( $info['code'] ) ) {
+          $discount_info = $info;
         }
       }
+    }
+    unset( $item );
 
-      $item['discount_used']   = $saved > 0 ? 1 : 0;
-      $item['discount_saved']  = round( $saved, 2 );
-      $discount_total         += $saved;
+    if ( $discount_code && $discount_info ) {
+      if ( 'flat' === $discount_info['type'] ) {
+        $discount_total = min( $total_before, $discount_info['amount'] );
+      } else {
+        $discount_total = $total_before * ( $discount_info['amount'] / 100 );
+      }
+    }
+
+    // Distribute savings proportionally across items
+    foreach ( $items as &$item ) {
+      $sub = $item['quantity'] * $item['price'];
+      $share = $total_before > 0 ? ( $sub / $total_before ) : 0;
+      $item_saved = $discount_total * $share;
+      $item['discount_used']  = $discount_total > 0 ? 1 : 0;
+      $item['discount_saved'] = round( $item_saved, 2 );
     }
     unset( $item );
 

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -128,8 +128,13 @@ class TTA_Cart {
     $total = 0;
     foreach ( $this->get_items() as $it ) {
       $sub = $it['quantity'] * $it['price'];
-      if ( $discount_code && strtolower( $discount_code ) === strtolower( $it['discountcode'] ) ) {
-        $sub *= 0.9; // 10% discount
+      $info = tta_parse_discount_data( $it['discountcode'] );
+      if ( $discount_code && $info['code'] && strtolower( $discount_code ) === strtolower( $info['code'] ) ) {
+        if ( 'flat' === $info['type'] ) {
+          $sub = max( 0, $sub - $info['amount'] );
+        } else {
+          $sub *= max( 0, 1 - ( $info['amount'] / 100 ) );
+        }
       }
       $total += $sub;
     }

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -150,7 +150,27 @@ class TTA_Cart {
    * This basic implementation simply empties the cart.
    * Hooked listeners can handle ticket delivery or payment processing.
    */
-  public function finalize_purchase() {
+  public function finalize_purchase( $transaction_id = '', $amount = 0 ) {
+    global $wpdb;
+
+    $items = $this->get_items();
+
+    // Decrement ticket availability for each item
+    foreach ( $items as $item ) {
+      $wpdb->query(
+        $wpdb->prepare(
+          "UPDATE {$wpdb->prefix}tta_tickets SET ticketlimit = GREATEST(ticketlimit - %d, 0) WHERE id = %d",
+          intval( $item['quantity'] ),
+          intval( $item['ticket_id'] )
+        )
+      );
+    }
+
+    // Log transaction details
+    if ( $transaction_id ) {
+      TTA_Transaction_Logger::log( $transaction_id, $amount, $items );
+    }
+
     $this->empty_cart();
     if ( isset( $_SESSION['tta_discount_code'] ) ) {
       unset( $_SESSION['tta_discount_code'] );

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -158,10 +158,12 @@ class TTA_Cart {
   public function finalize_purchase( $transaction_id = '', $amount = 0 ) {
     global $wpdb;
 
-    $items = $this->get_items();
+    $discount_code = $_SESSION['tta_discount_code'] ?? '';
+    $items         = $this->get_items();
+    $discount_total = 0;
 
-    // Decrement ticket availability for each item
-    foreach ( $items as $item ) {
+    // Decrement ticket availability and flag used discounts per item
+    foreach ( $items as &$item ) {
       $wpdb->query(
         $wpdb->prepare(
           "UPDATE {$wpdb->prefix}tta_tickets SET ticketlimit = GREATEST(ticketlimit - %d, 0) WHERE id = %d",
@@ -169,17 +171,35 @@ class TTA_Cart {
           intval( $item['ticket_id'] )
         )
       );
+
+      $sub  = $item['quantity'] * $item['price'];
+      $info = tta_parse_discount_data( $item['discountcode'] );
+      $saved = 0;
+      if ( $discount_code && $info['code'] && strtolower( $discount_code ) === strtolower( $info['code'] ) ) {
+        if ( 'flat' === $info['type'] ) {
+          $saved = min( $sub, $info['amount'] );
+        } else {
+          $saved = $sub * ( $info['amount'] / 100 );
+        }
+      }
+
+      $item['discount_used']   = $saved > 0 ? 1 : 0;
+      $item['discount_saved']  = round( $saved, 2 );
+      $discount_total         += $saved;
     }
+    unset( $item );
 
     // Log transaction details
     if ( $transaction_id ) {
-      TTA_Transaction_Logger::log( $transaction_id, $amount, $items );
+      TTA_Transaction_Logger::log( $transaction_id, $amount, $items, $discount_code, $discount_total );
     }
 
     $this->empty_cart();
-    if ( isset( $_SESSION['tta_discount_code'] ) ) {
-      unset( $_SESSION['tta_discount_code'] );
-    }
+    $wpdb->delete( $this->carts_table, [ 'id' => $this->cart_id ], [ '%d' ] );
+
+    unset( $_SESSION['tta_cart_session'] );
+    unset( $_SESSION['tta_discount_code'] );
+
     do_action( 'tta_checkout_complete', $this->cart_id );
   }
 }

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -193,6 +193,8 @@ class TTA_DB_Setup {
             member_id       BIGINT UNSIGNED NULL,
             transaction_id  VARCHAR(50)     NOT NULL,
             amount          DECIMAL(10,2)  NOT NULL,
+            discount_code   VARCHAR(255)   DEFAULT '',
+            discount_saved  DECIMAL(10,2)  DEFAULT 0.00,
             details         TEXT           NULL,
             created_at      DATETIME       DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY     (id),

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -183,6 +183,24 @@ class TTA_DB_Setup {
                 ON DELETE CASCADE
         ) $charset_collate";
 
+        // ─────────────────────────────────────────────────────────────────
+        // Transactions table
+        // ─────────────────────────────────────────────────────────────────
+        $sql_statements[] = "
+        CREATE TABLE {$prefix}transactions (
+            id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            wpuserid        BIGINT UNSIGNED NOT NULL,
+            member_id       BIGINT UNSIGNED NULL,
+            transaction_id  VARCHAR(50)     NOT NULL,
+            amount          DECIMAL(10,2)  NOT NULL,
+            details         TEXT           NULL,
+            created_at      DATETIME       DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY     (id),
+            KEY wpuserid_idx       (wpuserid),
+            KEY member_id_idx      (member_id),
+            KEY transaction_id_idx (transaction_id)
+        ) $charset_collate";
+
         // Run dbDelta on each statement
         foreach ( $sql_statements as $sql ) {
             dbDelta( $sql );

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -171,6 +171,17 @@ class TTA_Assets {
                 ]
             );
         }
+
+        // 4) Checkout Page template assets
+        if ( function_exists( 'is_page_template' ) && is_page_template( 'checkout-page-template.php' ) ) {
+            wp_enqueue_script(
+                'tta-checkout-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/checkout-expiration-mask.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
+        }
     }
 
 }

--- a/includes/classes/class-tta-transaction-logger.php
+++ b/includes/classes/class-tta-transaction-logger.php
@@ -1,0 +1,76 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Utility class to log completed transactions to the database
+ * and record member history entries.
+ */
+class TTA_Transaction_Logger {
+
+    /**
+     * Record a transaction along with its purchased items.
+     *
+     * @param string $transaction_id Authorize.Net transaction ID
+     * @param float  $amount         Total charged amount
+     * @param array  $items          Cart items from TTA_Cart::get_items()
+     * @param int    $user_id        Optional WordPress user ID
+     */
+    public static function log( $transaction_id, $amount, array $items, $user_id = 0 ) {
+        global $wpdb;
+
+        $user_id = $user_id ?: get_current_user_id();
+        $members_table = $wpdb->prefix . 'tta_members';
+        $history_table = $wpdb->prefix . 'tta_memberhistory';
+        $txn_table     = $wpdb->prefix . 'tta_transactions';
+
+        $member_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$members_table} WHERE wpuserid = %d LIMIT 1",
+                $user_id
+            )
+        );
+
+        // Save summary transaction row
+        $wpdb->insert(
+            $txn_table,
+            [
+                'wpuserid'       => $user_id,
+                'member_id'      => $member_id,
+                'transaction_id' => $transaction_id,
+                'amount'         => $amount,
+                'details'        => wp_json_encode( $items ),
+            ],
+            [ '%d', '%d', '%s', '%f', '%s' ]
+        );
+
+        // Record a history row per item for quick lookup by event
+        foreach ( $items as $item ) {
+            $event_id = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s",
+                    $item['event_ute_id']
+                )
+            );
+
+            $wpdb->insert(
+                $history_table,
+                [
+                    'member_id'   => $member_id ?: 0,
+                    'wpuserid'    => $user_id,
+                    'event_id'    => intval( $event_id ),
+                    'action_type' => 'purchase',
+                    'action_data' => wp_json_encode([
+                        'ticket_id'      => intval( $item['ticket_id'] ),
+                        'ticket_name'    => $item['ticket_name'],
+                        'quantity'       => intval( $item['quantity'] ),
+                        'price'          => floatval( $item['price'] ),
+                        'transaction_id' => $transaction_id,
+                    ]),
+                ],
+                [ '%d', '%d', '%d', '%s', '%s' ]
+            );
+        }
+    }
+}

--- a/includes/classes/class-tta-transaction-logger.php
+++ b/includes/classes/class-tta-transaction-logger.php
@@ -49,34 +49,33 @@ class TTA_Transaction_Logger {
             [ '%d', '%d', '%s', '%f', '%s', '%f', '%s' ]
         );
 
-        // Record a history row per item for quick lookup by event
-        foreach ( $items as $item ) {
+        // Record a single history row for this transaction
+        $event_id = 0;
+        if ( ! empty( $items[0]['event_ute_id'] ) ) {
             $event_id = $wpdb->get_var(
                 $wpdb->prepare(
-                    "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s",
-                    $item['event_ute_id']
+                    "SELECT id FROM {$wpdb->prefix}tta_events WHERE ute_id = %s LIMIT 1",
+                    $items[0]['event_ute_id']
                 )
             );
-
-            $wpdb->insert(
-                $history_table,
-                [
-                    'member_id'   => $member_id ?: 0,
-                    'wpuserid'    => $user_id,
-                    'event_id'    => intval( $event_id ),
-                    'action_type' => 'purchase',
-                    'action_data' => wp_json_encode([
-                        'ticket_id'      => intval( $item['ticket_id'] ),
-                        'ticket_name'    => $item['ticket_name'],
-                        'quantity'       => intval( $item['quantity'] ),
-                        'price'          => floatval( $item['price'] ),
-                        'discount_used'  => ! empty( $item['discount_used'] ) ? 1 : 0,
-                        'discount_saved' => floatval( $item['discount_saved'] ?? 0 ),
-                        'transaction_id' => $transaction_id,
-                    ]),
-                ],
-                [ '%d', '%d', '%d', '%s', '%s' ]
-            );
         }
+
+        $wpdb->insert(
+            $history_table,
+            [
+                'member_id'   => $member_id ?: 0,
+                'wpuserid'    => $user_id,
+                'event_id'    => intval( $event_id ),
+                'action_type' => 'purchase',
+                'action_data' => wp_json_encode([
+                    'items'          => $items,
+                    'transaction_id' => $transaction_id,
+                    'discount_code'  => $discount_code,
+                    'discount_saved' => $discount_saved,
+                    'amount'         => $amount,
+                ]),
+            ],
+            [ '%d', '%d', '%d', '%s', '%s' ]
+        );
     }
 }

--- a/includes/classes/class-tta-transaction-logger.php
+++ b/includes/classes/class-tta-transaction-logger.php
@@ -15,9 +15,11 @@ class TTA_Transaction_Logger {
      * @param string $transaction_id Authorize.Net transaction ID
      * @param float  $amount         Total charged amount
      * @param array  $items          Cart items from TTA_Cart::get_items()
+     * @param string $discount_code  Discount code used at checkout
+     * @param float  $discount_saved Total savings from discounts
      * @param int    $user_id        Optional WordPress user ID
      */
-    public static function log( $transaction_id, $amount, array $items, $user_id = 0 ) {
+    public static function log( $transaction_id, $amount, array $items, $discount_code = '', $discount_saved = 0, $user_id = 0 ) {
         global $wpdb;
 
         $user_id = $user_id ?: get_current_user_id();
@@ -40,9 +42,11 @@ class TTA_Transaction_Logger {
                 'member_id'      => $member_id,
                 'transaction_id' => $transaction_id,
                 'amount'         => $amount,
+                'discount_code'  => $discount_code,
+                'discount_saved' => $discount_saved,
                 'details'        => wp_json_encode( $items ),
             ],
-            [ '%d', '%d', '%s', '%f', '%s' ]
+            [ '%d', '%d', '%s', '%f', '%s', '%f', '%s' ]
         );
 
         // Record a history row per item for quick lookup by event
@@ -66,6 +70,8 @@ class TTA_Transaction_Logger {
                         'ticket_name'    => $item['ticket_name'],
                         'quantity'       => intval( $item['quantity'] ),
                         'price'          => floatval( $item['price'] ),
+                        'discount_used'  => ! empty( $item['discount_used'] ) ? 1 : 0,
+                        'discount_saved' => floatval( $item['discount_saved'] ?? 0 ),
                         'transaction_id' => $transaction_id,
                     ]),
                 ],

--- a/includes/frontend/templates/checkout-page-template.php
+++ b/includes/frontend/templates/checkout-page-template.php
@@ -54,7 +54,7 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] )
         );
 
         if ( $result['success'] ) {
-            $cart->finalize_purchase();
+            $cart->finalize_purchase( $result['transaction_id'], $amount );
             wp_safe_redirect( add_query_arg( 'checkout', 'done', get_permalink() ) );
             exit;
         } else {

--- a/includes/frontend/templates/checkout-page-template.php
+++ b/includes/frontend/templates/checkout-page-template.php
@@ -21,10 +21,13 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] )
     $discount_code = $_SESSION['tta_discount_code'] ?? '';
     $amount = $cart->get_total( $discount_code );
 
-    $exp_parts = explode( '/', sanitize_text_field( $_POST['card_exp'] ) );
+    $exp_input = sanitize_text_field( $_POST['card_exp'] );
     $exp_date  = '';
-    if ( count( $exp_parts ) === 2 ) {
-        $exp_date = '20' . str_pad( $exp_parts[1], 2, '0', STR_PAD_LEFT ) . '-' . str_pad( $exp_parts[0], 2, '0', STR_PAD_LEFT );
+    if ( preg_match( '/^(0[1-9]|1[0-2])\/\d{2}$/', $exp_input ) ) {
+        $exp_parts = explode( '/', $exp_input );
+        $exp_date  = '20' . $exp_parts[1] . '-' . $exp_parts[0];
+    } else {
+        $checkout_error = __( 'Invalid expiration date format.', 'tta' );
     }
 
     $billing = [
@@ -36,21 +39,23 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] )
         'zip'        => sanitize_text_field( $_POST['billing_zip'] ),
     ];
 
-    $api    = new TTA_AuthorizeNet_API();
-    $result = $api->charge(
-        $amount,
-        preg_replace( '/\D/', '', $_POST['card_number'] ),
-        $exp_date,
-        sanitize_text_field( $_POST['card_cvc'] ),
-        $billing
-    );
+    if ( empty( $checkout_error ) ) {
+        $api    = new TTA_AuthorizeNet_API();
+        $result = $api->charge(
+            $amount,
+            preg_replace( '/\D/', '', $_POST['card_number'] ),
+            $exp_date,
+            sanitize_text_field( $_POST['card_cvc'] ),
+            $billing
+        );
 
-    if ( $result['success'] ) {
-        $cart->finalize_purchase();
-        wp_safe_redirect( add_query_arg( 'checkout', 'done', get_permalink() ) );
-        exit;
-    } else {
-        $checkout_error = $result['error'];
+        if ( $result['success'] ) {
+            $cart->finalize_purchase();
+            wp_safe_redirect( add_query_arg( 'checkout', 'done', get_permalink() ) );
+            exit;
+        } else {
+            $checkout_error = $result['error'];
+        }
     }
 }
 
@@ -131,7 +136,7 @@ $checkout_done = isset( $_GET['checkout'] ) && 'done' === $_GET['checkout'];
             <p>
                 <label>
                     <?php esc_html_e( 'Expiration', 'tta' ); ?><br />
-                    <input type="text" name="card_exp" placeholder="MM/YY" required />
+                    <input type="text" id="tta-card-exp" name="card_exp" placeholder="MM/YY" required />
                 </label>
             </p>
             <p>

--- a/includes/frontend/templates/checkout-page-template.php
+++ b/includes/frontend/templates/checkout-page-template.php
@@ -19,11 +19,17 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] )
     $discount_code = $_SESSION['tta_discount_code'] ?? '';
     $amount = $cart->get_total( $discount_code );
 
-    $exp_input = sanitize_text_field( $_POST['card_exp'] );
-    $exp_date  = '';
-    if ( preg_match( '/^(0[1-9]|1[0-2])\/\d{2}$/', $exp_input ) ) {
-        $exp_parts = explode( '/', $exp_input );
-        $exp_date  = '20' . $exp_parts[1] . '-' . $exp_parts[0];
+    $exp_input  = sanitize_text_field( $_POST['card_exp'] );
+    $exp_digits = preg_replace( '/\D/', '', $exp_input );
+    $exp_date   = '';
+    if ( strlen( $exp_digits ) === 4 ) {
+        $month = substr( $exp_digits, 0, 2 );
+        $year  = substr( $exp_digits, 2, 2 );
+        if ( (int) $month >= 1 && (int) $month <= 12 ) {
+            $exp_date = '20' . $year . '-' . $month;
+        } else {
+            $checkout_error = __( 'Invalid expiration month.', 'tta' );
+        }
     } else {
         $checkout_error = __( 'Invalid expiration date format.', 'tta' );
     }
@@ -136,7 +142,7 @@ $checkout_done = isset( $_GET['checkout'] ) && 'done' === $_GET['checkout'];
             <p>
                 <label>
                     <?php esc_html_e( 'Expiration', 'tta' ); ?><br />
-                    <input type="text" id="tta-card-exp" name="card_exp" placeholder="MM/YY" required />
+                    <input type="text" id="tta-card-exp" name="card_exp" placeholder="MM/YY" required maxlength="5" pattern="\d{2}/\d{2}" inputmode="numeric" />
                 </label>
             </p>
             <p>

--- a/includes/frontend/templates/checkout-page-template.php
+++ b/includes/frontend/templates/checkout-page-template.php
@@ -10,11 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Initialize cart early for sessions
-$cart = new TTA_Cart();
-
-get_header();
-
+$cart          = new TTA_Cart();
 $checkout_error = '';
+
 if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] ) ) {
     check_admin_referer( 'tta_checkout_action', 'tta_checkout_nonce' );
 
@@ -58,6 +56,8 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['tta_do_checkout'] )
         }
     }
 }
+
+get_header();
 
 $discount_code = $_SESSION['tta_discount_code'] ?? '';
 $items         = $cart->get_items();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -63,6 +63,63 @@ function tta_get_us_states() {
 }
 
 /**
+ * Decode a discount string stored in the events table.
+ *
+ * @param string $raw
+ * @return array{code:string,type:string,amount:float}
+ */
+function tta_parse_discount_data( $raw ) {
+    $default = [ 'code' => '', 'type' => 'percent', 'amount' => 0 ];
+    if ( ! $raw ) {
+        return $default;
+    }
+
+    $data = json_decode( $raw, true );
+    if ( is_array( $data ) && isset( $data['code'] ) ) {
+        $code   = sanitize_text_field( $data['code'] );
+        $type   = in_array( $data['type'], [ 'flat', 'percent' ], true ) ? $data['type'] : 'percent';
+        $amount = floatval( $data['amount'] ?? 0 );
+        return [
+            'code'   => $code,
+            'type'   => $type,
+            'amount' => $amount,
+        ];
+    }
+
+    // Legacy plain code string defaults to 10% discount
+    return [
+        'code'   => sanitize_text_field( $raw ),
+        'type'   => 'percent',
+        'amount' => 10,
+    ];
+}
+
+/**
+ * Encode discount data for storage.
+ *
+ * @param string $code
+ * @param string $type
+ * @param float  $amount
+ * @return string
+ */
+function tta_build_discount_data( $code, $type = 'percent', $amount = 0 ) {
+    $code   = sanitize_text_field( $code );
+    if ( '' === $code ) {
+        return '';
+    }
+    $type   = in_array( $type, [ 'flat', 'percent' ], true ) ? $type : 'percent';
+    $amount = floatval( $amount );
+
+    $data = [
+        'code'   => $code,
+        'type'   => $type,
+        'amount' => $amount,
+    ];
+
+    return wp_json_encode( $data );
+}
+
+/**
  * Render the cart table HTML for the given cart.
  *
  * @param TTA_Cart $cart


### PR DESCRIPTION
## Summary
- validate the expiration date format before charging the card
- skip API call when expiration date is invalid
- auto-insert a slash in the expiration date field as users type

## Testing
- `composer -n test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850240fe1708320ac6a41cc18f6307c