### PR TITLE
Add DB indexes and unit test

### DIFF
--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -56,7 +56,9 @@ class TTA_DB_Setup {
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY  (id),
-            KEY ute_id (ute_id)
+            KEY ute_id (ute_id),
+            KEY page_id_idx (page_id),
+            KEY date_idx (date)
         ) $charset_collate";
 
         // ─────────────────────────────────────────────────────────────────
@@ -89,6 +91,7 @@ class TTA_DB_Setup {
             opt_in_event_update_sms         TINYINT(1) DEFAULT 0,
             PRIMARY KEY  (id),
             KEY wpuserid_idx (wpuserid),
+            KEY name_idx (last_name, first_name),
             UNIQUE KEY email (email)
         ) $charset_collate";
 
@@ -157,7 +160,8 @@ class TTA_DB_Setup {
             expires_at   DATETIME        NOT NULL,
             locked_until DATETIME        NULL,
             PRIMARY KEY    (id),
-            UNIQUE KEY     session_key_idx (session_key)
+            UNIQUE KEY     session_key_idx (session_key),
+            KEY expires_at_idx (expires_at)
         ) $charset_collate";
 
         // ─────────────────────────────────────────────────────────────────

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/DbSetupTest.php
+++ b/tests/DbSetupTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class DbSetupTest extends TestCase {
+    private $captured = [];
+
+    protected function setUp(): void {
+        // Minimal WP constants and globals
+        if (!defined('ABSPATH')) {
+            $tmp = sys_get_temp_dir() . '/wp/';
+            define('ABSPATH', $tmp);
+            @mkdir(ABSPATH . 'wp-admin/includes', 0777, true);
+            file_put_contents(ABSPATH . 'wp-admin/includes/upgrade.php', "<?php\n" );
+        }
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function get_charset_collate() {
+                return 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
+            }
+        };
+        $GLOBALS['captured_sql'] = [];
+        if (!function_exists('dbDelta')) {
+            function dbDelta($sql) { $GLOBALS['captured_sql'][] = $sql; }
+        }
+        if (!function_exists('register_activation_hook')) {
+            function register_activation_hook($file, $callback) {}
+        }
+        require_once __DIR__ . '/../includes/class-db-setup.php';
+        \TTA_DB_Setup::install();
+        $this->captured = $GLOBALS['captured_sql'];
+    }
+
+    public function test_indexes_added() {
+        $sql = implode("\n", $this->captured);
+        $this->assertStringContainsString('KEY page_id_idx (page_id)', $sql);
+        $this->assertStringContainsString('KEY date_idx (date)', $sql);
+        $this->assertStringContainsString('KEY expires_at_idx (expires_at)', $sql);
+        $this->assertStringContainsString('KEY name_idx (last_name, first_name)', $sql);
+    }
+}


### PR DESCRIPTION
## Summary
- add new DB indexes for events, members and carts tables
- create PHPUnit configuration and DbSetupTest
- verify new indexes in the unit test

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68508306b94c8320949d0dc38371e44d