### PR TITLE
Fix event page to skip unknown social links

### DIFF
--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -566,8 +566,8 @@ if ( $ticket_count > 1 ) {
                   continue;
               }
 
-              $host = parse_url( $url, PHP_URL_HOST );
-              $service_key = 'external-link.svg'; // default icon
+              $host        = parse_url( $url, PHP_URL_HOST );
+              $service_key = '';
 
               if ( $host ) {
                   $host = strtolower( $host );
@@ -577,6 +577,11 @@ if ( $ticket_count > 1 ) {
                           break;
                       }
                   }
+              }
+
+              // Skip unknown services entirely
+              if ( empty( $service_key ) ) {
+                  continue;
               }
 
               $additional_links[] = [


### PR DESCRIPTION
## Summary
- skip unknown platform links on the event page template

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6851733618dc8320b08a2123e5c4797e