### PR TITLE
Add cart item timer and event limit

### DIFF
--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -275,6 +275,12 @@
   margin: 0 8px;
   font-size: 1em;
 }
+.tta-ticket-notice {
+  color: #b00;
+  font-size: 0.9em;
+  margin-top: 4px;
+  display: none;
+}
 
 /* Get Tickets button */
 #tta-get-tickets {

--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -282,6 +282,18 @@
   display: none;
 }
 
+/* Disabled controls */
+.tta-disabled,
+button[disabled],
+input[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+#tta-get-tickets:disabled {
+  cursor: not-allowed;
+}
+
 /* Get Tickets button */
 #tta-get-tickets {
   display: inline-block;

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -51,3 +51,29 @@ jQuery(function($){
     });
   });
 })(jQuery);
+
+jQuery(function($){
+  function showNotice($input, msg){
+    var $wrap = $input.closest('.tta-ticket-quantity');
+    var $n = $wrap.find('.tta-ticket-notice');
+    if(!$n.length) return;
+    $n.text(msg).fadeIn(200);
+    clearTimeout($n.data('timer'));
+    $n.data('timer', setTimeout(function(){ $n.fadeOut(200); }, 4000));
+  }
+
+  function enforceLimit(){
+    var $input = $(this);
+    var total = 0;
+    $('.tta-qty-input').each(function(){ total += parseInt($(this).val(),10)||0; });
+    if(total > 2){
+      var others = total - parseInt($input.val(),10)||0;
+      var allowed = Math.max(0, 2 - others);
+      $input.val(allowed);
+      var msg = $('.tta-qty-input').length > 1 ? tta_event.multi_limit_msg : tta_event.single_limit_msg;
+      showNotice($input, msg);
+    }
+  }
+
+  $(document).on('change', '.tta-qty-input', enforceLimit);
+});

--- a/assets/js/frontend/tta-cart.js
+++ b/assets/js/frontend/tta-cart.js
@@ -83,11 +83,11 @@ jQuery(function($){
     clearTimers();
     $('.tta-cart-table tbody tr').each(function(){
       var $row = $(this);
-      var remain = parseInt($row.data('expire'),10) || 0;
+      var expireAt = parseInt($row.data('expire-at'),10) * 1000;
       var $cd = $row.find('.tta-countdown');
-      if(!remain || !$cd.length) return;
-      var intv = setInterval(function(){
-        remain--;
+      if(!expireAt || !$cd.length) return;
+      function update(){
+        var remain = Math.floor((expireAt - Date.now())/1000);
         if(remain <= 0){
           clearInterval(intv);
           $row.find('.tta-remove-item').click();
@@ -96,10 +96,17 @@ jQuery(function($){
         var m = Math.floor(remain/60);
         var s = remain % 60;
         $cd.text(m+':' + (s<10?'0':'')+s);
-      },1000);
+      }
+      update();
+      var intv = setInterval(update,1000);
       countdownTimers.push(intv);
     });
   }
 
   startTimers();
+  document.addEventListener('visibilitychange', function(){
+    if(!document.hidden){
+      startTimers();
+    }
+  });
 });

--- a/assets/js/frontend/tta-cart.js
+++ b/assets/js/frontend/tta-cart.js
@@ -1,4 +1,5 @@
 jQuery(function($){
+  var countdownTimers = [];
   // Quantity controls
   $('.tta-qty-increase').on('click', function(){
     var $input = $(this).closest('.tta-ticket-quantity').find('.tta-qty-input');
@@ -45,6 +46,7 @@ jQuery(function($){
 
   function sendCartUpdate(){
     var payload = collectCartData();
+    clearTimers();
     payload.action = 'tta_update_cart';
     payload.nonce  = tta_ajax.nonce;
 
@@ -60,6 +62,7 @@ jQuery(function($){
           alert(res.data.message || 'Error updating cart.');
           $('#tta-cart-container').fadeTo(200,1);
         }
+        startTimers();
       }, 1000);
     }, 'json');
   }
@@ -72,7 +75,12 @@ jQuery(function($){
     sendCartUpdate();
   });
 
+  function clearTimers(){
+    countdownTimers.forEach(clearInterval);
+    countdownTimers = [];
+  }
   function startTimers(){
+    clearTimers();
     $('.tta-cart-table tbody tr').each(function(){
       var $row = $(this);
       var remain = parseInt($row.data('expire'),10) || 0;
@@ -89,6 +97,7 @@ jQuery(function($){
         var s = remain % 60;
         $cd.text(m+':' + (s<10?'0':'')+s);
       },1000);
+      countdownTimers.push(intv);
     });
   }
 

--- a/assets/js/frontend/tta-cart.js
+++ b/assets/js/frontend/tta-cart.js
@@ -71,4 +71,26 @@ jQuery(function($){
     $('input[name="cart_qty['+id+']"]').val(0);
     sendCartUpdate();
   });
+
+  function startTimers(){
+    $('.tta-cart-table tbody tr').each(function(){
+      var $row = $(this);
+      var remain = parseInt($row.data('expire'),10) || 0;
+      var $cd = $row.find('.tta-countdown');
+      if(!remain || !$cd.length) return;
+      var intv = setInterval(function(){
+        remain--;
+        if(remain <= 0){
+          clearInterval(intv);
+          $row.find('.tta-remove-item').click();
+          return;
+        }
+        var m = Math.floor(remain/60);
+        var s = remain % 60;
+        $cd.text(m+':' + (s<10?'0':'')+s);
+      },1000);
+    });
+  }
+
+  startTimers();
 });

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -12,6 +12,8 @@ This document summarizes the current logic around the cart and checkout process 
 
 2. **Viewing the Cart**
    - The **Cart Page** template renders the current cart contents using `tta_render_cart_contents()`.
+   - Each cart row now shows the linked event name above the ticket type along with a live five minute countdown.
+   - Countdown timers remove items immediately when they expire.
    - Quantities and discount codes are updated via the `tta_update_cart` AJAX endpoint. This calls `TTA_Cart::update_quantity()` and stores a discount code in the session.
 
 3. **Checkout**
@@ -26,6 +28,7 @@ This document summarizes the current logic around the cart and checkout process 
 ## Branching Logic Highlights
 
 - Pricing logic branches on membership level when adding items to the cart.
+- Each member may purchase a maximum of two tickets per event. Quantities in the cart plus past purchases are checked during the `tta_add_to_cart` AJAX request.
 - Checkout can branch if inventory changes mid-process, redirecting back to the cart with a notice.
 - Payment failure stops checkout and displays the returned error.
 - Successful completion empties the cart and fires hooks for additional actions (e.g., ticket emails).

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -8,7 +8,7 @@ This document summarizes the current logic around the cart and checkout process 
    - Visitors interact with the **Event Page** template. When the page loads a `TTA_Cart` instance is created so session data exists early.
    - Ticket details are fetched from the database. Prices vary depending on membership level (`free`, `basic`, or `premium`).
    - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
-   - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add.
+   - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add and the related event cache is cleared.
 
 2. **Viewing the Cart**
    - The **Cart Page** template renders the current cart contents using `tta_render_cart_contents()`.
@@ -26,7 +26,7 @@ This document summarizes the current logic around the cart and checkout process 
 4. **Cleanup**
    - `TTA_Cart_Cleanup` schedules an hourly task and also runs on checkout completion to remove expired cart rows.
    - A second cron task runs every ten minutes to purge expired cart items and free their ticket inventory.
-   - Expired items are deleted from carts automatically and their reserved stock is released back to the ticket pool.
+   - Expired items are deleted from carts automatically and their reserved stock is released back to the ticket pool. When this occurs the event ticket cache is also cleared so front‑end counts stay in sync.
 
 ## Branching Logic Highlights
 

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -7,7 +7,7 @@ This document summarizes the current logic around the cart and checkout process 
 1. **Adding Tickets**
    - Visitors interact with the **Event Page** template. When the page loads a `TTA_Cart` instance is created so session data exists early.
    - Ticket details are fetched from the database. Prices vary depending on membership level (`free`, `basic`, or `premium`).
-   - Quantity selectors on the event page prevent selecting more than two tickets in total. A notice appears when the limit would be exceeded.
+   - Quantity selectors on the event page prevent selecting more than two tickets in total. A notice appears when the limit would be exceeded. Sold out ticket rows have their quantity controls disabled and the **Get Tickets** button is disabled if no tickets remain.
    - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
    - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add and the related event cache is cleared.
 

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -7,8 +7,8 @@ This document summarizes the current logic around the cart and checkout process 
 1. **Adding Tickets**
    - Visitors interact with the **Event Page** template. When the page loads a `TTA_Cart` instance is created so session data exists early.
    - Ticket details are fetched from the database. Prices vary depending on membership level (`free`, `basic`, or `premium`).
-   - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the appropriate price and calls `TTA_Cart::add_item()`.
-   - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID.
+   - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
+   - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add.
 
 2. **Viewing the Cart**
    - The **Cart Page** template renders the current cart contents using `tta_render_cart_contents()`.
@@ -20,11 +20,12 @@ This document summarizes the current logic around the cart and checkout process 
    - The **Checkout Page** template performs checkout when the form is submitted (`tta_do_checkout`).
    - `TTA_Cart::sync_with_inventory()` ensures requested quantities are still available. If inventory changed, a notice is stored and the user is redirected back to the cart.
    - A total is calculated with any discount code applied. Payment details are sent to `TTA_AuthorizeNet_API::charge()`.
-   - On success, `TTA_Cart::finalize_purchase()` reduces ticket inventory atomically, logs the transaction, clears the cart tables, and triggers the `tta_checkout_complete` action. On failure, an error message is shown.
+   - On success, `TTA_Cart::finalize_purchase()` logs the transaction, clears the cart tables, and triggers the `tta_checkout_complete` action. Inventory has already been reserved when items were added.
 
 4. **Cleanup**
    - `TTA_Cart_Cleanup` schedules an hourly task and also runs on checkout completion to remove expired cart rows.
    - A second cron task runs every ten minutes to purge expired cart items and free their ticket inventory.
+   - Expired items are deleted from carts automatically and their reserved stock is released back to the ticket pool.
 
 ## Branching Logic Highlights
 

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -24,6 +24,7 @@ This document summarizes the current logic around the cart and checkout process 
 
 4. **Cleanup**
    - `TTA_Cart_Cleanup` schedules an hourly task and also runs on checkout completion to remove expired cart rows.
+   - A second cron task runs every ten minutes to purge expired cart items and free their ticket inventory.
 
 ## Branching Logic Highlights
 

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -7,6 +7,7 @@ This document summarizes the current logic around the cart and checkout process 
 1. **Adding Tickets**
    - Visitors interact with the **Event Page** template. When the page loads a `TTA_Cart` instance is created so session data exists early.
    - Ticket details are fetched from the database. Prices vary depending on membership level (`free`, `basic`, or `premium`).
+   - Quantity selectors on the event page prevent selecting more than two tickets in total. A notice appears when the limit would be exceeded.
    - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
    - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add and the related event cache is cleared.
 

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -7,6 +7,7 @@ This document summarizes the current logic around the cart and checkout process 
 1. **Adding Tickets**
    - Visitors interact with the **Event Page** template. When the page loads a `TTA_Cart` instance is created so session data exists early.
    - Ticket details are fetched from the database. Prices vary depending on membership level (`free`, `basic`, or `premium`).
+   - Expired cart items are cleared before ticket data loads so availability displays correctly.
    - Quantity selectors on the event page prevent selecting more than two tickets in total. A notice appears when the limit would be exceeded. Sold out ticket rows have their quantity controls disabled and the **Get Tickets** button is disabled if no tickets remain.
    - When a user adds tickets, the browser issues an AJAX request to `tta_add_to_cart`. The handler calculates the price, reserves inventory, and calls `TTA_Cart::add_item()`.
    - Cart data is stored in the `tta_carts` and `tta_cart_items` tables keyed by a session ID. Ticket availability is decreased immediately on add and the related event cache is cleared.
@@ -15,7 +16,8 @@ This document summarizes the current logic around the cart and checkout process 
    - The **Cart Page** template renders the current cart contents using `tta_render_cart_contents()`.
    - Each cart row now shows the linked event name above the ticket type along with a live five minute countdown.
    - Countdown timers remove items immediately when they expire.
-    - Timers restart after any AJAX update so they remain visible.
+    - Timers calculate remaining time from the expiration timestamp so they stay accurate when the tab is hidden.
+    - Timers restart after any AJAX update or when the page regains focus.
    - Quantities and discount codes are updated via the `tta_update_cart` AJAX endpoint. This calls `TTA_Cart::update_quantity()` and stores a discount code in the session.
 
 3. **Checkout**

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -14,6 +14,7 @@ This document summarizes the current logic around the cart and checkout process 
    - The **Cart Page** template renders the current cart contents using `tta_render_cart_contents()`.
    - Each cart row now shows the linked event name above the ticket type along with a live five minute countdown.
    - Countdown timers remove items immediately when they expire.
+    - Timers restart after any AJAX update so they remain visible.
    - Quantities and discount codes are updated via the `tta_update_cart` AJAX endpoint. This calls `TTA_Cart::update_quantity()` and stores a discount code in the session.
 
 3. **Checkout**

--- a/docs/ObjectCaching.md
+++ b/docs/ObjectCaching.md
@@ -16,6 +16,7 @@ This document outlines the object caching layer used by the Trying To Adult Mana
 
 - Whenever an event or its tickets are created or updated (via the admin pages or AJAX), `TTA_Cache::flush()` runs to clear all plugin caches.
 - This helps prevent confusing situations where an admin edits content but the front‑end still shows old data.
+- Ticket availability changes from cart activity or cleanup delete the affected event's ticket cache so numbers stay current.
 
 ## Clearing the Cache Manually
 

--- a/includes/ajax/handlers/class-ajax-cart.php
+++ b/includes/ajax/handlers/class-ajax-cart.php
@@ -39,13 +39,19 @@ class TTA_Ajax_Cart {
 
         $cart = new TTA_Cart();
 
+        $existing = [];
+        foreach ( $cart->get_items() as $row ) {
+            $e = $row['event_ute_id'];
+            $existing[ $e ] = ( $existing[ $e ] ?? 0 ) + intval( $row['quantity'] );
+        }
+
         foreach ( $items as $it ) {
             $ticket_id = intval( $it['ticket_id'] );
             $qty       = intval( $it['quantity'] );
 
             $ticket = $wpdb->get_row(
                 $wpdb->prepare(
-                    "SELECT baseeventcost, discountedmembercost, premiummembercost
+                    "SELECT event_ute_id, baseeventcost, discountedmembercost, premiummembercost
                      FROM {$wpdb->prefix}tta_tickets
                      WHERE id = %d",
                     $ticket_id
@@ -54,6 +60,13 @@ class TTA_Ajax_Cart {
             );
             if ( ! $ticket ) {
                 continue;
+            }
+
+            $event_ute = $ticket['event_ute_id'];
+            $purchased = is_user_logged_in() ? tta_get_purchased_ticket_count( get_current_user_id(), $event_ute ) : 0;
+            $allowed   = max( 0, 2 - $purchased - ( $existing[ $event_ute ] ?? 0 ) );
+            if ( $qty > $allowed ) {
+                $qty = $allowed;
             }
 
             if ( 'basic' === $membership_level ) {
@@ -68,6 +81,7 @@ class TTA_Ajax_Cart {
                 $cart->remove_item( $ticket_id );
             } else {
                 $cart->add_item( $ticket_id, $qty, $price );
+                $existing[ $event_ute ] = ( $existing[ $event_ute ] ?? 0 ) + $qty;
             }
         }
 

--- a/includes/cart/class-cart-cleanup.php
+++ b/includes/cart/class-cart-cleanup.php
@@ -23,11 +23,49 @@ class TTA_Cart_Cleanup {
     }
 
     /**
-     * Schedule the hourly cleanup event if not already scheduled.
+     * Delete expired cart items and release their ticket inventory.
+     */
+    public static function clean_expired_items() {
+        global $wpdb;
+
+        $items_table  = $wpdb->prefix . 'tta_cart_items';
+        $tickets_table = $wpdb->prefix . 'tta_tickets';
+
+        $expired = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT ticket_id, quantity FROM {$items_table} WHERE expires_at < %s",
+                current_time( 'mysql' )
+            ),
+            ARRAY_A
+        );
+
+        foreach ( $expired as $row ) {
+            $wpdb->query(
+                $wpdb->prepare(
+                    "UPDATE {$tickets_table} SET ticketlimit = ticketlimit + %d WHERE id = %d",
+                    intval( $row['quantity'] ),
+                    intval( $row['ticket_id'] )
+                )
+            );
+        }
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$items_table} WHERE expires_at < %s",
+                current_time( 'mysql' )
+            )
+        );
+    }
+
+    /**
+     * Schedule cleanup events if not already scheduled.
      */
     public static function schedule_event() {
         if ( ! wp_next_scheduled( 'tta_cart_cleanup_event' ) ) {
             wp_schedule_event( time(), 'hourly', 'tta_cart_cleanup_event' );
+        }
+        if ( ! wp_next_scheduled( 'tta_cart_item_cleanup_event' ) ) {
+            wp_schedule_event( time(), 'tta_ten_minutes', 'tta_cart_item_cleanup_event' );
         }
     }
 
@@ -36,6 +74,7 @@ class TTA_Cart_Cleanup {
      */
     public static function clear_event() {
         wp_clear_scheduled_hook( 'tta_cart_cleanup_event' );
+        wp_clear_scheduled_hook( 'tta_cart_item_cleanup_event' );
     }
 
     /**
@@ -44,6 +83,21 @@ class TTA_Cart_Cleanup {
     public static function init() {
         add_action( 'tta_checkout_complete', [ __CLASS__, 'clean_expired_carts' ] );
         add_action( 'tta_cart_cleanup_event', [ __CLASS__, 'clean_expired_carts' ] );
+        add_action( 'tta_cart_item_cleanup_event', [ __CLASS__, 'clean_expired_items' ] );
+        add_filter( 'cron_schedules', [ __CLASS__, 'add_schedule' ] );
         self::schedule_event();
+    }
+
+    /**
+     * Register a 10 minute schedule for WP cron.
+     */
+    public static function add_schedule( $schedules ) {
+        if ( ! isset( $schedules['tta_ten_minutes'] ) ) {
+            $schedules['tta_ten_minutes'] = [
+                'interval' => 600,
+                'display'  => 'Every Ten Minutes',
+            ];
+        }
+        return $schedules;
     }
 }

--- a/includes/cart/class-cart-cleanup.php
+++ b/includes/cart/class-cart-cleanup.php
@@ -33,11 +33,12 @@ class TTA_Cart_Cleanup {
 
         $expired = $wpdb->get_results(
             $wpdb->prepare(
-                "SELECT ticket_id, quantity FROM {$items_table} WHERE expires_at < %s",
+                "SELECT i.ticket_id, i.quantity, t.event_ute_id FROM {$items_table} i JOIN {$tickets_table} t ON i.ticket_id = t.id WHERE i.expires_at < %s",
                 current_time( 'mysql' )
             ),
             ARRAY_A
         );
+        $touched_events = [];
 
         foreach ( $expired as $row ) {
             $wpdb->query(
@@ -47,6 +48,9 @@ class TTA_Cart_Cleanup {
                     intval( $row['ticket_id'] )
                 )
             );
+            if ( ! empty( $row['event_ute_id'] ) ) {
+                $touched_events[ $row['event_ute_id'] ] = true;
+            }
         }
 
         $wpdb->query(
@@ -55,6 +59,10 @@ class TTA_Cart_Cleanup {
                 current_time( 'mysql' )
             )
         );
+
+        foreach ( array_keys( $touched_events ) as $evt ) {
+            TTA_Cache::delete( 'tickets_' . $evt );
+        }
     }
 
     /**

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -56,21 +56,77 @@ class TTA_Cart {
     }
   }
 
+  /**
+   * Adjust ticket inventory when reserving or releasing items.
+   *
+   * @param int $ticket_id Ticket ID.
+   * @param int $qty_diff  Positive number to release, negative to reserve.
+   */
+  protected function adjust_inventory( $ticket_id, $qty_diff ) {
+    $ticket_id = intval( $ticket_id );
+    $qty_diff  = intval( $qty_diff );
+    if ( 0 === $qty_diff ) {
+      return;
+    }
+
+    if ( $qty_diff < 0 ) {
+      // Reserve stock only if enough tickets remain.
+      $this->wpdb->query(
+        $this->wpdb->prepare(
+          "UPDATE {$this->wpdb->prefix}tta_tickets SET ticketlimit = ticketlimit + %d WHERE id = %d AND ticketlimit >= %d",
+          $qty_diff,
+          $ticket_id,
+          -$qty_diff
+        )
+      );
+    } else {
+      // Release previously reserved stock.
+      $this->wpdb->query(
+        $this->wpdb->prepare(
+          "UPDATE {$this->wpdb->prefix}tta_tickets SET ticketlimit = ticketlimit + %d WHERE id = %d",
+          $qty_diff,
+          $ticket_id
+        )
+      );
+    }
+  }
+
   public function add_item( $ticket_id, $qty, $price ) {
     $this->ensure_cart( true );
+    $ticket_id = intval( $ticket_id );
+    $qty       = intval( $qty );
     if ( $qty <= 0 ) {
       $this->remove_item( $ticket_id );
       return;
     }
 
-    $exists = $this->wpdb->get_var(
+    $existing_qty = (int) $this->wpdb->get_var(
       $this->wpdb->prepare(
-        "SELECT COUNT(*) FROM {$this->items_table} WHERE cart_id = %d AND ticket_id = %d",
+        "SELECT quantity FROM {$this->items_table} WHERE cart_id = %d AND ticket_id = %d",
         $this->cart_id,
         $ticket_id
       )
     );
-    if ( $exists ) {
+    $diff = $qty - $existing_qty;
+
+    if ( $diff > 0 ) {
+      $available = (int) $this->wpdb->get_var(
+        $this->wpdb->prepare(
+          "SELECT ticketlimit FROM {$this->wpdb->prefix}tta_tickets WHERE id = %d",
+          $ticket_id
+        )
+      );
+      if ( $available < $diff ) {
+        $qty  = $existing_qty + $available;
+        $diff = $available;
+      }
+    }
+
+    if ( $diff !== 0 ) {
+      $this->adjust_inventory( $ticket_id, -$diff );
+    }
+
+    if ( $existing_qty ) {
       $this->wpdb->update(
         $this->items_table,
         [ 'quantity' => $qty, 'price' => $price ],
@@ -95,20 +151,75 @@ class TTA_Cart {
 
   public function update_quantity( $ticket_id, $qty ) {
     $this->ensure_cart( true );
+    $ticket_id   = intval( $ticket_id );
+    $qty         = intval( $qty );
+    $existing_qty = (int) $this->wpdb->get_var(
+      $this->wpdb->prepare(
+        "SELECT quantity FROM {$this->items_table} WHERE cart_id = %d AND ticket_id = %d",
+        $this->cart_id,
+        $ticket_id
+      )
+    );
+
     if ( $qty <= 0 ) {
       $this->remove_item( $ticket_id );
-    } else {
+      return;
+    }
+
+    $diff = $qty - $existing_qty;
+    if ( $diff > 0 ) {
+      $available = (int) $this->wpdb->get_var(
+        $this->wpdb->prepare(
+          "SELECT ticketlimit FROM {$this->wpdb->prefix}tta_tickets WHERE id = %d",
+          $ticket_id
+        )
+      );
+      if ( $available < $diff ) {
+        $qty  = $existing_qty + $available;
+        $diff = $available;
+      }
+    }
+
+    if ( $diff !== 0 ) {
+      $this->adjust_inventory( $ticket_id, -$diff );
+    }
+
+    if ( $existing_qty ) {
       $this->wpdb->update(
         $this->items_table,
         [ 'quantity' => $qty ],
         [ 'cart_id' => $this->cart_id, 'ticket_id' => $ticket_id ],
         ['%d'],['%d','%d']
       );
+    } else {
+      $expire = date( 'Y-m-d H:i:s', time() + 300 );
+      $this->wpdb->insert(
+        $this->items_table,
+        [
+          'cart_id'   => $this->cart_id,
+          'ticket_id' => $ticket_id,
+          'quantity'  => $qty,
+          'price'     => 0,
+          'expires_at' => $expire,
+        ],
+        ['%d','%d','%d','%f','%s']
+      );
     }
   }
 
   public function remove_item( $ticket_id ) {
     $this->ensure_cart( false );
+    $ticket_id = intval( $ticket_id );
+    $qty = (int) $this->wpdb->get_var(
+      $this->wpdb->prepare(
+        "SELECT quantity FROM {$this->items_table} WHERE cart_id = %d AND ticket_id = %d",
+        $this->cart_id,
+        $ticket_id
+      )
+    );
+    if ( $qty ) {
+      $this->adjust_inventory( $ticket_id, $qty );
+    }
     $this->wpdb->delete(
       $this->items_table,
       [ 'cart_id' => $this->cart_id, 'ticket_id' => $ticket_id ],
@@ -237,32 +348,7 @@ class TTA_Cart {
       }
     }
 
-    // Decrement availability atomically
-    $updated = [];
     foreach ( $items as &$item ) {
-      $affected = $wpdb->query(
-        $wpdb->prepare(
-          "UPDATE {$wpdb->prefix}tta_tickets SET ticketlimit = ticketlimit - %d WHERE id = %d AND ticketlimit >= %d",
-          intval( $item['quantity'] ),
-          intval( $item['ticket_id'] ),
-          intval( $item['quantity'] )
-        )
-      );
-      if ( ! $affected ) {
-        // revert any previous adjustments
-        foreach ( $updated as $u ) {
-          $wpdb->query(
-            $wpdb->prepare(
-              "UPDATE {$wpdb->prefix}tta_tickets SET ticketlimit = ticketlimit + %d WHERE id = %d",
-              intval( $u['qty'] ),
-              intval( $u['id'] )
-            )
-          );
-        }
-        return new WP_Error( 'tta_sold_out', __( 'Not enough tickets remain.', 'tta' ) );
-      }
-      $updated[] = [ 'id' => $item['ticket_id'], 'qty' => $item['quantity'] ];
-
       $sub  = $item['quantity'] * $item['price'];
       $total_before += $sub;
 

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -89,6 +89,17 @@ class TTA_Cart {
         )
       );
     }
+
+    // Invalidate cached ticket data for this event.
+    $event_ute_id = $this->wpdb->get_var(
+      $this->wpdb->prepare(
+        "SELECT event_ute_id FROM {$this->wpdb->prefix}tta_tickets WHERE id = %d",
+        $ticket_id
+      )
+    );
+    if ( $event_ute_id ) {
+      TTA_Cache::delete( 'tickets_' . $event_ute_id );
+    }
   }
 
   public function add_item( $ticket_id, $qty, $price ) {

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -78,6 +78,7 @@ class TTA_Cart {
         ['%d','%f'],['%d','%d']
       );
     } else {
+      $expire = date( 'Y-m-d H:i:s', time() + 300 );
       $this->wpdb->insert(
         $this->items_table,
         [
@@ -85,8 +86,9 @@ class TTA_Cart {
           'ticket_id' => $ticket_id,
           'quantity'  => $qty,
           'price'     => $price,
+          'expires_at' => $expire,
         ],
-        ['%d','%d','%d','%f']
+        ['%d','%d','%d','%f','%s']
       );
     }
   }
@@ -114,11 +116,27 @@ class TTA_Cart {
     );
   }
 
+  protected function expire_items() {
+    $this->ensure_cart( false );
+    $expired = $this->wpdb->get_results(
+      $this->wpdb->prepare(
+        "SELECT ticket_id FROM {$this->items_table} WHERE cart_id = %d AND expires_at <= %s",
+        $this->cart_id,
+        current_time('mysql')
+      ),
+      ARRAY_A
+    );
+    foreach ( $expired as $row ) {
+      $this->remove_item( intval( $row['ticket_id'] ) );
+    }
+  }
+
   public function get_items() {
     $this->ensure_cart( false );
+    $this->expire_items();
     return $this->wpdb->get_results(
       $this->wpdb->prepare(
-          "SELECT ci.*, t.ticket_name, t.event_ute_id, e.discountcode
+          "SELECT ci.*, t.ticket_name, t.event_ute_id, e.discountcode, e.name AS event_name, e.page_id
          FROM {$this->items_table} ci
          JOIN {$this->wpdb->prefix}tta_tickets t ON ci.ticket_id = t.id
          LEFT JOIN {$this->wpdb->prefix}tta_events e ON t.event_ute_id = e.ute_id

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -174,6 +174,8 @@ class TTA_DB_Setup {
             ticket_id  BIGINT UNSIGNED NOT NULL,
             quantity   INT UNSIGNED     NOT NULL,
             price      DECIMAL(10,2)    NOT NULL,
+            added_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            expires_at DATETIME        NOT NULL,
             PRIMARY KEY   (id),
             KEY cart_idx   (cart_id),
             KEY ticket_idx (ticket_id),

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -143,6 +143,14 @@ class TTA_Assets {
                     'nonce'    => wp_create_nonce( 'tta_frontend_nonce' ),
                 ]
             );
+            wp_localize_script(
+                'tta-eventpage-js',
+                'tta_event',
+                [
+                    'single_limit_msg' => __( "We're sorry, there's a limit of two tickets per event.", 'tta' ),
+                    'multi_limit_msg'  => __( "We're sorry, there's a limit of two tickets total per event.", 'tta' ),
+                ]
+            );
         }
 
         // 3) Cart Page template assets

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -411,6 +411,7 @@ if ( $ticket_count > 1 ) {
                   />
                   <button type="button" class="tta-qty-increase" aria-label="<?php esc_attr_e( 'Increase quantity', 'tta' ); ?>">+</button>
                 </div>
+                <div class="tta-ticket-notice" aria-live="polite"></div>
               </div>
             </div>
           <?php endforeach; ?>

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -368,7 +368,15 @@ if ( $ticket_count > 1 ) {
         <h2><?php esc_html_e( 'Get Your Tickets Now', 'tta' ); ?></h2>
 
         <?php if ( $tickets ) : ?>
-          <?php foreach ( $tickets as $ticket ) :
+          <?php
+            $all_sold_out = true;
+            foreach ( $tickets as $ticket ) {
+                if ( intval( $ticket['ticketlimit'] ) > 0 ) {
+                    $all_sold_out = false;
+                    break;
+                }
+            }
+            foreach ( $tickets as $ticket ) :
             $limit      = intval( $ticket['ticketlimit'] );
             $available  = $limit > 0 ? $limit : 0;
             $avail_text = $available > 0
@@ -393,6 +401,7 @@ if ( $ticket_count > 1 ) {
                 $price_row = "<span class='tta-ticket-price tta-event-costmod-class'><strong>Cost: </strong>{$pb}</span>";
             }
         ?>
+            <?php $is_sold_out = $available < 1; ?>
             <div class="tta-top-indiv-wrapper">
               <div class="tta-ticket-item">
                 <?php echo $price_row . ' ' . $avail_text; ?>
@@ -400,16 +409,17 @@ if ( $ticket_count > 1 ) {
               <div class="tta-ticket-quantity">
                 <span class="tta-ticket-name"><?php echo esc_html( $ticket['ticket_name'] ); ?></span>
                 <div>
-                  <button type="button" class="tta-qty-decrease" aria-label="<?php esc_attr_e( 'Decrease quantity', 'tta' ); ?>">–</button>
+                  <button type="button" class="tta-qty-decrease<?php echo $is_sold_out ? ' tta-disabled' : ''; ?>" aria-label="<?php esc_attr_e( 'Decrease quantity', 'tta' ); ?>" <?php disabled( $is_sold_out ); ?>>–</button>
                   <input
                     type="number"
                     name="tta_ticket_qty[<?php echo esc_attr( $ticket['id'] ); ?>]"
-                    class="tta-qty-input"
+                    class="tta-qty-input<?php echo $is_sold_out ? ' tta-disabled' : ''; ?>"
                     value="<?php echo esc_attr( $cart_quantities[ $ticket['id'] ] ?? 0 ); ?>"
                     min="0"
                     <?php if ( $available ): ?>max="<?php echo esc_attr( $available ); ?>"<?php endif; ?>
+                    <?php disabled( $is_sold_out ); ?>
                   />
-                  <button type="button" class="tta-qty-increase" aria-label="<?php esc_attr_e( 'Increase quantity', 'tta' ); ?>">+</button>
+                  <button type="button" class="tta-qty-increase<?php echo $is_sold_out ? ' tta-disabled' : ''; ?>" aria-label="<?php esc_attr_e( 'Increase quantity', 'tta' ); ?>" <?php disabled( $is_sold_out ); ?>>+</button>
                 </div>
                 <div class="tta-ticket-notice" aria-live="polite"></div>
               </div>
@@ -423,8 +433,8 @@ if ( $ticket_count > 1 ) {
           <button
             type="button"
             id="tta-get-tickets"
-            class="tta-button tta-button-primary"
-            <?php disabled( empty( $tickets ) || intval( $tickets[0]['ticketlimit'] ) < 1 ); ?>
+            class="tta-button tta-button-primary<?php echo $all_sold_out ? ' tta-disabled' : ''; ?>"
+            <?php disabled( empty( $tickets ) || $all_sold_out ); ?>
           >
             <?php esc_html_e( 'Get Tickets', 'tta' ); ?>
           </button>

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -7,6 +7,7 @@
 
 // Initialize cart early so sessions start before output
 $cart = new TTA_Cart();
+$cart_items = $cart->get_items();
 
 // ───────────────
 // 1) Load custom header (without the page-header block)
@@ -61,7 +62,7 @@ $ticket_count = count( $tickets );
 
 // Build a map of quantities for this event from the cart
 $cart_quantities = [];
-foreach ( $cart->get_items() as $it ) {
+foreach ( $cart_items as $it ) {
     if ( isset( $it['event_ute_id'] ) && $it['event_ute_id'] === $event['ute_id'] ) {
         $cart_quantities[ intval( $it['ticket_id'] ) ] = intval( $it['quantity'] );
     }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -150,6 +150,34 @@ function tta_get_cart_notice() {
 }
 
 /**
+ * Get count of tickets a user has already purchased for an event.
+ *
+ * @param int    $user_id
+ * @param string $event_ute_id
+ * @return int
+ */
+function tta_get_purchased_ticket_count( $user_id, $event_ute_id ) {
+    global $wpdb;
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT action_data FROM {$wpdb->prefix}tta_memberhistory WHERE wpuserid = %d AND action_type = 'purchase'",
+            $user_id
+        ),
+        ARRAY_A
+    );
+    $total = 0;
+    foreach ( $rows as $row ) {
+        $data = json_decode( $row['action_data'], true );
+        foreach ( (array) ( $data['items'] ?? [] ) as $it ) {
+            if ( ( $it['event_ute_id'] ?? '' ) === $event_ute_id ) {
+                $total += intval( $it['quantity'] );
+            }
+        }
+    }
+    return $total;
+}
+
+/**
  * Render the cart table HTML for the given cart.
  *
  * @param TTA_Cart $cart
@@ -174,8 +202,15 @@ function tta_render_cart_contents( TTA_Cart $cart, $discount_code = '' ) {
             <tbody>
                 <?php foreach ( $items as $it ) : ?>
                     <?php $sub = $it['quantity'] * $it['price']; ?>
-                    <tr>
-                        <td><?php echo esc_html( $it['ticket_name'] ); ?></td>
+                    <?php $remain = max( 0, strtotime( $it['expires_at'] ) - time() ); ?>
+                    <tr data-expire="<?php echo esc_attr( $remain ); ?>">
+                        <td>
+                            <a href="<?php echo esc_url( get_permalink( $it['page_id'] ) ); ?>">
+                                <?php echo esc_html( $it['event_name'] ); ?>
+                            </a><br>
+                            <?php echo esc_html( $it['ticket_name'] ); ?>
+                            <span class="tta-countdown"></span>
+                        </td>
                         <td>
                             <input type="number" name="cart_qty[<?php echo esc_attr( $it['ticket_id'] ); ?>]" value="<?php echo esc_attr( $it['quantity'] ); ?>" min="0" class="tta-cart-qty">
                         </td>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -202,8 +202,8 @@ function tta_render_cart_contents( TTA_Cart $cart, $discount_code = '' ) {
             <tbody>
                 <?php foreach ( $items as $it ) : ?>
                     <?php $sub = $it['quantity'] * $it['price']; ?>
-                    <?php $remain = max( 0, strtotime( $it['expires_at'] ) - time() ); ?>
-                    <tr data-expire="<?php echo esc_attr( $remain ); ?>">
+                    <?php $expire_at = strtotime( $it['expires_at'] ); ?>
+                    <tr data-expire-at="<?php echo esc_attr( $expire_at ); ?>">
                         <td>
                             <a href="<?php echo esc_url( get_permalink( $it['page_id'] ) ); ?>">
                                 <?php echo esc_html( $it['event_name'] ); ?>

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -108,6 +108,7 @@ class CartTest extends TestCase {
         if(!function_exists('wp_generate_uuid4')){ function wp_generate_uuid4(){ return 'x'; } }
         if(!function_exists('current_time')){ function current_time($t='mysql'){ return 'now'; } }
         if(!function_exists('get_current_user_id')){ function get_current_user_id(){ return 0; } }
+        if(!function_exists('home_url')){ function home_url($p=''){ return '/'.$p; } }
         require_once __DIR__ . '/../includes/cart/class-cart.php';
         $cart = new TTA_Cart();
         $cart->add_item(5,1,10);
@@ -149,5 +150,51 @@ class CartTest extends TestCase {
         $cart = new TTA_Cart();
         $cart->add_item(5,1,10);
         $this->assertArrayNotHasKey('tta_cache_tickets_ev1', $transients);
+    }
+
+    public function test_ajax_add_to_cart_enforces_limit(){
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $items = [];
+            public $insert_id = 1;
+            public function get_row($q,$o=ARRAY_A){
+                return [
+                    'event_ute_id'=>'ev1',
+                    'baseeventcost'=>10,
+                    'discountedmembercost'=>8,
+                    'premiummembercost'=>7
+                ];
+            }
+            public function get_var($q){
+                if (strpos($q,'ticketlimit')!==false) return 5;
+                return null;
+            }
+            public function get_results($q,$o=ARRAY_A){ return []; }
+            public function prepare($q,...$a){ foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1);} return $q; }
+            public function query($q){ return 1; }
+            public function insert($t,$d,$f){ if(isset($d['ticket_id'])){ $this->items[$d['ticket_id']]=$d['quantity']; } }
+            public function update($t,$d,$w,$f1=null,$f2=null){ if(isset($w['ticket_id'])){ $this->items[$w['ticket_id']]=$d['quantity']; } }
+            public function delete($t,$w,$f){ }
+        };
+        if(!function_exists('check_ajax_referer')){ function check_ajax_referer($a,$b){} }
+        if(!function_exists('wp_send_json_success')){ function wp_send_json_success($d){ $GLOBALS['_last_json']=['success'=>true,'data'=>$d]; return $GLOBALS['_last_json']; } }
+        if(!function_exists('wp_send_json_error')){ function wp_send_json_error($d){ $GLOBALS['_last_json']=['success'=>false,'data'=>$d]; return $GLOBALS['_last_json']; } }
+        if(!function_exists('add_action')){ function add_action($t,$c){} }
+        if(!function_exists('is_user_logged_in')){ function is_user_logged_in(){ return false; } }
+        if(!function_exists('wp_generate_uuid4')){ function wp_generate_uuid4(){ return 'x'; } }
+        if(!function_exists('current_time')){ function current_time($t='mysql'){ return 'now'; } }
+        if(!function_exists('get_current_user_id')){ function get_current_user_id(){ return 0; } }
+
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/cart/class-cart.php';
+        require_once __DIR__ . '/../includes/ajax/handlers/class-ajax-cart.php';
+
+        $_POST['items'] = json_encode([['ticket_id'=>1,'quantity'=>3]]);
+        $_POST['nonce'] = 'n';
+
+        TTA_Ajax_Cart::ajax_add_to_cart();
+
+        $this->assertSame(2, $wpdb->items[1]);
     }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -60,7 +60,7 @@ class CartTest extends TestCase {
         function get_permalink($id){return 'post/'.$id;}
         $html = tta_render_cart_contents($cart,'');
         $this->assertStringContainsString('post/55',$html);
-        $this->assertStringContainsString('data-expire', $html);
+        $this->assertStringContainsString('data-expire-at', $html);
     }
 
     public function test_item_cleanup_queries(){

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -20,6 +20,9 @@ class DummyWpdbCartHelper {
 
 class CartTest extends TestCase {
     protected function setUp(): void {
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', sys_get_temp_dir() . '/wp/');
+        }
         if (!function_exists('esc_html')) { function esc_html($v){ return $v; } }
         if (!function_exists('esc_html_e')) { function esc_html_e($s,$d=null){ echo $s; } }
         if (!function_exists('esc_attr')) { function esc_attr($v){ return $v; } }
@@ -78,5 +81,39 @@ class CartTest extends TestCase {
         $sql = implode("\n", $wpdb->queries);
         $this->assertStringContainsString('wp_tta_cart_items', $sql);
         $this->assertStringContainsString('wp_tta_tickets', $sql);
+    }
+
+    public function test_add_and_remove_adjusts_inventory(){
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $queries = [];
+            public $insert_id = 1;
+            public $items = [];
+            public function get_row($q,$o=ARRAY_A){ $this->queries[]=$q; return null; }
+            public function get_var($q){
+                $this->queries[]=$q;
+                if(strpos($q,'ticketlimit')!==false) return 5;
+                if(preg_match('/SELECT quantity FROM (\S+) WHERE cart_id = (\d+) AND ticket_id = (\d+)/',$q,$m)){
+                    return $this->items[$m[3]] ?? null;
+                }
+                return null;
+            }
+            public function prepare($q,...$a){ foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1); } return $q; }
+            public function query($q){ $this->queries[]=$q; return 1; }
+            public function insert($t,$d,$f){ $this->queries[]='INSERT'; if(isset($d['ticket_id'])){ $this->items[$d['ticket_id']]=$d['quantity']; } }
+            public function update($t,$d,$w,$f1=null,$f2=null){ $this->queries[]='UPDATE'; if(isset($w['ticket_id'])){ $this->items[$w['ticket_id']]=$d['quantity']; } }
+            public function delete($t,$w,$f){ $this->queries[]='DELETE'; unset($this->items[$w['ticket_id']]); }
+        };
+        if(!function_exists('wp_generate_uuid4')){ function wp_generate_uuid4(){ return 'x'; } }
+        if(!function_exists('current_time')){ function current_time($t='mysql'){ return 'now'; } }
+        if(!function_exists('get_current_user_id')){ function get_current_user_id(){ return 0; } }
+        require_once __DIR__ . '/../includes/cart/class-cart.php';
+        $cart = new TTA_Cart();
+        $cart->add_item(5,1,10);
+        $cart->remove_item(5);
+        $sql = implode("\n", $wpdb->queries);
+        $this->assertStringContainsString('ticketlimit = ticketlimit + -1', $sql);
+        $this->assertStringContainsString('ticketlimit = ticketlimit + 1', $sql);
     }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -197,4 +197,25 @@ class CartTest extends TestCase {
 
         $this->assertSame(2, $wpdb->items[1]);
     }
+
+    public function test_ticket_controls_disabled_when_sold_out(){
+        $tickets = [
+            ['id'=>1,'ticket_name'=>'VIP','ticketlimit'=>0,'baseeventcost'=>10,'discountedmembercost'=>8,'premiummembercost'=>7],
+            ['id'=>2,'ticket_name'=>'GA','ticketlimit'=>0,'baseeventcost'=>5,'discountedmembercost'=>4,'premiummembercost'=>3]
+        ];
+        ob_start();
+        $all_sold_out = true;
+        foreach($tickets as $t){ if(intval($t['ticketlimit'])>0){ $all_sold_out = false; break; } }
+        foreach($tickets as $t){
+            $limit = intval($t['ticketlimit']);
+            $available = $limit > 0 ? $limit : 0;
+            $is_sold_out = $available < 1;
+            echo '<button class="tta-qty-increase'.($is_sold_out?' tta-disabled':'').'"'.($is_sold_out?' disabled':'').'>+</button>';
+        }
+        echo '<button id="tta-get-tickets"'.($all_sold_out?' disabled':'').'></button>';
+        $html = ob_get_clean();
+        $this->assertStringContainsString('tta-disabled', $html);
+        $this->assertStringContainsString('id="tta-get-tickets"', $html);
+        $this->assertStringContainsString('disabled', $html);
+    }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1,0 +1,62 @@
+<?php
+use PHPUnit\Framework\TestCase;
+if (!defined('ARRAY_A')) { define('ARRAY_A','ARRAY_A'); }
+
+class DummyWpdbCartHelper {
+    public $prefix = 'wp_';
+    public $data = [];
+    public function get_results($query,$output=ARRAY_A){
+        if(preg_match('/FROM (\S+) WHERE wpuserid = (\d+)/',$query,$m)){
+            $table=$m[1]; $uid=intval($m[2]);
+            return $this->data[$table][$uid] ?? [];
+        }
+        return [];
+    }
+    public function prepare($q,...$a){
+        foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1); }
+        return $q;
+    }
+}
+
+class CartTest extends TestCase {
+    protected function setUp(): void {
+        if (!function_exists('esc_html')) { function esc_html($v){ return $v; } }
+        if (!function_exists('esc_html_e')) { function esc_html_e($s,$d=null){ echo $s; } }
+        if (!function_exists('esc_attr')) { function esc_attr($v){ return $v; } }
+        if (!function_exists('esc_url')) { function esc_url($v){ return $v; } }
+    }
+    public function test_get_purchased_ticket_count(){
+        global $wpdb;
+        $wpdb = new DummyWpdbCartHelper();
+        $wpdb->data['wp_tta_memberhistory'][1][] = ['action_data'=> json_encode(['items'=>[['event_ute_id'=>'ev1','quantity'=>1]]])];
+        $wpdb->data['wp_tta_memberhistory'][1][] = ['action_data'=> json_encode(['items'=>[['event_ute_id'=>'ev1','quantity'=>2]]])];
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/cart/class-cart.php';
+        $count = tta_get_purchased_ticket_count(1,'ev1');
+        $this->assertSame(3,$count);
+    }
+
+    public function test_render_cart_contains_event_link(){
+        global $wpdb;
+        $wpdb = new stdClass();
+        require_once __DIR__ . '/../includes/helpers.php';
+        require_once __DIR__ . '/../includes/cart/class-cart.php';
+        $cart = $this->createMock('TTA_Cart');
+        $cart->method('get_items')->willReturn([
+            [
+                'ticket_id'=>1,
+                'ticket_name'=>'VIP',
+                'quantity'=>1,
+                'price'=>10,
+                'event_name'=>'Party',
+                'page_id'=>55,
+                'expires_at'=> date('Y-m-d H:i:s', time()+60)
+            ]
+        ]);
+        $cart->method('get_total')->willReturn(10);
+        function get_permalink($id){return 'post/'.$id;}
+        $html = tta_render_cart_contents($cart,'');
+        $this->assertStringContainsString('post/55',$html);
+        $this->assertStringContainsString('data-expire', $html);
+    }
+}

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -116,4 +116,38 @@ class CartTest extends TestCase {
         $this->assertStringContainsString('ticketlimit = ticketlimit + -1', $sql);
         $this->assertStringContainsString('ticketlimit = ticketlimit + 1', $sql);
     }
+
+    public function test_inventory_updates_clear_cache(){
+        global $wpdb, $transients;
+        $transients = ['tta_cache_tickets_ev1' => ['foo']];
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $queries = [];
+            public $items = [];
+            public function get_var($q){
+                if (strpos($q,'event_ute_id')!==false) return 'ev1';
+                if(preg_match('/SELECT quantity FROM (\S+) WHERE cart_id = (\d+) AND ticket_id = (\d+)/',$q,$m)){
+                    return $this->items[$m[3]] ?? null;
+                }
+                return 5;
+            }
+            public function get_row($q,$o=ARRAY_A){ $this->queries[]=$q; return null; }
+            public function prepare($q,...$a){ foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1);} return $q; }
+            public function query($q){ $this->queries[]=$q; return 1; }
+            public function insert($t,$d,$f){ $this->queries[]='INSERT'; if(isset($d['ticket_id'])){ $this->items[$d['ticket_id']]=$d['quantity']; } }
+            public function update($t,$d,$w,$f1=null,$f2=null){ $this->queries[]='UPDATE'; if(isset($w['ticket_id'])){ $this->items[$w['ticket_id']]=$d['quantity']; } }
+            public function delete($t,$w,$f){ $this->queries[]='DELETE'; unset($this->items[$w['ticket_id']]); }
+        };
+        if(!function_exists('get_transient')){ function get_transient($k){ global $transients; return $transients[$k] ?? false; } }
+        if(!function_exists('set_transient')){ function set_transient($k,$v,$t=0){ global $transients; $transients[$k]=$v; } }
+        if(!function_exists('delete_transient')){ function delete_transient($k){ global $transients; unset($transients[$k]); } }
+        if(!function_exists('wp_generate_uuid4')){ function wp_generate_uuid4(){ return 'x'; } }
+        if(!function_exists('current_time')){ function current_time($t='mysql'){ return 'now'; } }
+        if(!function_exists('get_current_user_id')){ function get_current_user_id(){ return 0; } }
+        require_once __DIR__ . '/../includes/classes/class-tta-cache.php';
+        require_once __DIR__ . '/../includes/cart/class-cart.php';
+        $cart = new TTA_Cart();
+        $cart->add_item(5,1,10);
+        $this->assertArrayNotHasKey('tta_cache_tickets_ev1', $transients);
+    }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -59,4 +59,24 @@ class CartTest extends TestCase {
         $this->assertStringContainsString('post/55',$html);
         $this->assertStringContainsString('data-expire', $html);
     }
+
+    public function test_item_cleanup_queries(){
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $queries = [];
+            public function get_results($q,$o=ARRAY_A){
+                $this->queries[] = $q;
+                return [['ticket_id'=>5,'quantity'=>2]];
+            }
+            public function query($q){ $this->queries[] = $q; }
+            public function prepare($q,...$a){ foreach($a as $v){ $q=preg_replace('/%d/',$v,$q,1); $q=preg_replace('/%s/',$v,$q,1);} return $q; }
+        };
+        if(!function_exists('current_time')){ function current_time($t){ return 'now'; } }
+        require_once __DIR__ . '/../includes/cart/class-cart-cleanup.php';
+        TTA_Cart_Cleanup::clean_expired_items();
+        $sql = implode("\n", $wpdb->queries);
+        $this->assertStringContainsString('wp_tta_cart_items', $sql);
+        $this->assertStringContainsString('wp_tta_tickets', $sql);
+    }
 }


### PR DESCRIPTION
## Summary
- show linked event names and countdown timers in cart
- add per-event ticket purchase limit logic
- automatically purge expired cart items
- document cart flow additions
- test new helper methods and rendering

## Testing
- `composer install`
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6851b6584a348320a08bc03f2b0bf3c0