### PR TITLE
Add SQL docs for importing users and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Without these values, checkout will fail and an admin notice will be displayed.
 - [Input Sanitization Helpers](docs/InputSanitization.md)
 - [Event Page Context](docs/EventPage.md)
 - [Event Type Options](docs/EventTypes.md)
+- [Testing Information](docs/TestingInformation.md) (includes sandbox credit card numbers)
+- [Development SQL Assets](docs/DevelopmentSQL.md)
 - [Project TODOs](TODO.md)
 
 ## Running Tests

--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -396,6 +396,19 @@ input[disabled] {
   margin-right: 5px;
 }
 
+/* Your Events section */
+.tta-your-events-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.tta-your-events-list li {
+  margin-bottom: .5em;
+}
+.tta-your-events-list .logout-icon {
+  transform: rotate(180deg);
+}
+
 .tta-accordion-content.expanded::after {
   opacity: 0;                      /* hide the fade */
 }

--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -198,6 +198,27 @@
   margin: 20px 0;
 }
 
+.tta-login-accordion .tta-accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  padding: 0;
+  transition: max-height 0.4s ease, padding 0.4s ease;
+}
+
+.tta-login-accordion .tta-accordion-content.expanded {
+  max-height: 400px;
+  padding: 20px 0 0;
+}
+
+.tta-button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #0073aa;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* Ticket context text */
 .tta-ticket-context {
   margin: 0 0 15px;

--- a/assets/images/public/event-page-icons/billing.svg
+++ b/assets/images/public/event-page-icons/billing.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" height="512">
+  <path d="M32 2a2 2 0 0 1 2 2v12h-4V6H12v52h18v-10h4v12a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm22.3 29H26v4h28.3l-8.7 8.7 2.8 2.8L62 32l-13.6-13.5-2.8 2.8z"/>
+</svg>

--- a/assets/images/public/event-page-icons/login.svg
+++ b/assets/images/public/event-page-icons/login.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" height="512">
+  <path d="M32 2a2 2 0 0 1 2 2v12h-4V6H12v52h18v-10h4v12a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm22.3 29H26v4h28.3l-8.7 8.7 2.8 2.8L62 32l-13.6-13.5-2.8 2.8z"/>
+</svg>

--- a/assets/images/public/event-page-icons/past.svg
+++ b/assets/images/public/event-page-icons/past.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" height="512">
+  <path d="M32 2a2 2 0 0 1 2 2v12h-4V6H12v52h18v-10h4v12a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm22.3 29H26v4h28.3l-8.7 8.7 2.8 2.8L62 32l-13.6-13.5-2.8 2.8z"/>
+</svg>

--- a/assets/images/public/event-page-icons/profile.svg
+++ b/assets/images/public/event-page-icons/profile.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" height="512">
+  <path d="M32 2a2 2 0 0 1 2 2v12h-4V6H12v52h18v-10h4v12a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm22.3 29H26v4h28.3l-8.7 8.7 2.8 2.8L62 32l-13.6-13.5-2.8 2.8z"/>
+</svg>

--- a/assets/images/public/event-page-icons/upcoming.svg
+++ b/assets/images/public/event-page-icons/upcoming.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" height="512">
+  <path d="M32 2a2 2 0 0 1 2 2v12h-4V6H12v52h18v-10h4v12a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm22.3 29H26v4h28.3l-8.7 8.7 2.8 2.8L62 32l-13.6-13.5-2.8 2.8z"/>
+</svg>

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -40,7 +40,7 @@ jQuery(function($){
     var headerHeight   = $(headerSelector).first().outerHeight() || 0;
     var extraOffset    = 200; // extra space below header
 
-    $('a[href="#tta-event-buy"]').on('click', function(e){
+  $('a[href="#tta-event-buy"]').on('click', function(e){
       e.preventDefault();
       var target = $('#tta-event-buy');
       if ( target.length ) {
@@ -49,6 +49,18 @@ jQuery(function($){
         }, 600);
       }
     });
+  });
+
+  $('.tta-scroll-login').on('click', function(e){
+    e.preventDefault();
+    var target = $('#tta-login-message');
+    if ( target.length ) {
+      $('html, body').animate({
+        scrollTop: target.offset().top - headerHeight - extraOffset
+      }, 600, function(){
+        target.find('.tta-accordion-toggle-login').trigger('click');
+      });
+    }
   });
 })(jQuery);
 

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -75,5 +75,22 @@ jQuery(function($){
     }
   }
 
-  $(document).on('change', '.tta-qty-input', enforceLimit);
+$(document).on('change', '.tta-qty-input', enforceLimit);
+});
+
+jQuery(function($){
+  $('.tta-accordion-toggle-login').on('click', function(){
+    var $btn  = $(this),
+        $cont = $btn.closest('.tta-accordion').find('.tta-accordion-content'),
+        loginText = 'Log in here',
+        hideText  = 'Hide login';
+
+    if ( $cont.hasClass('expanded') ) {
+      $cont.removeClass('expanded');
+      $btn.text( loginText );
+    } else {
+      $cont.addClass('expanded');
+      $btn.text( hideText );
+    }
+  });
 });

--- a/assets/js/frontend/member-dashboard.js
+++ b/assets/js/frontend/member-dashboard.js
@@ -26,6 +26,15 @@ jQuery(function($){
     $('#tab-' + tab).show();
   });
 
+  // Activate tab based on URL hash
+  var hashTab = window.location.hash.replace('#tab-', '');
+  if ( hashTab ) {
+    var $trigger = $('.tta-dashboard-tabs li[data-tab="' + hashTab + '"]');
+    if ( $trigger.length ) {
+      $trigger.trigger('click');
+    }
+  }
+
   // 3) Add/remove interests
   $('#add-interest-edit').on('click', function(e){
     e.preventDefault();

--- a/docs/DevelopmentSQL.md
+++ b/docs/DevelopmentSQL.md
@@ -1,0 +1,113 @@
+# Development SQL Assets
+
+This document collects helpful SQL snippets for testing and development. They are designed for a local sandbox WordPress environment.
+
+## Import WordPress users into `tta_members`
+
+```sql
+INSERT INTO `wp_j9bzlz98u3_tta_members` (
+  wpuserid,
+  first_name,
+  last_name,
+  email,
+  joined_at
+)
+SELECT
+  ID AS wpuserid,
+  -- take the first word of display_name as first_name
+  CASE
+    WHEN display_name LIKE '% %'
+      THEN SUBSTRING_INDEX(display_name, ' ', 1)
+    ELSE display_name
+  END AS first_name,
+  -- everything after the first space as last_name (or blank)
+  CASE
+    WHEN display_name LIKE '% %'
+      THEN SUBSTRING(display_name, LOCATE(' ', display_name) + 1)
+    ELSE ''
+  END AS last_name,
+  user_email AS email,
+  user_registered AS joined_at
+FROM
+  `wp_j9bzlz98u3_users`;
+```
+
+## Re-create and populate `tta_events` and `tta_tickets`
+
+```sql
+-- Disable foreign key checks to allow dropping
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- Drop existing tables
+DROP TABLE IF EXISTS `wp_j9bzlz98u3_tta_tickets`;
+DROP TABLE IF EXISTS `wp_j9bzlz98u3_tta_events`;
+
+-- Re-create tta_tickets
+CREATE TABLE `wp_j9bzlz98u3_tta_tickets` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `event_ute_id` VARCHAR(255) NOT NULL,
+  `event_name` VARCHAR(255) NOT NULL,
+  `ticket_name` VARCHAR(255) NOT NULL,
+  `waitlist_id` BIGINT UNSIGNED NOT NULL,
+  `ticketlimit` INT UNSIGNED NOT NULL,
+  `baseeventcost` DECIMAL(10,2) NOT NULL,
+  `discountedmembercost` DECIMAL(10,2) NOT NULL,
+  `premiummembercost` DECIMAL(10,2) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Re-create tta_events
+CREATE TABLE `wp_j9bzlz98u3_tta_events` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ute_id` VARCHAR(255) NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `date` DATE NOT NULL,
+  `baseeventcost` DECIMAL(10,2) NOT NULL,
+  `discountedmembercost` DECIMAL(10,2) NOT NULL,
+  `premiummembercost` DECIMAL(10,2) NOT NULL,
+  `address` VARCHAR(255) NOT NULL,
+  `type` VARCHAR(50) NOT NULL,
+  `time` VARCHAR(50) NOT NULL,
+  `venuename` VARCHAR(255) NOT NULL,
+  `venueurl` VARCHAR(2083) DEFAULT NULL,
+  `url2` VARCHAR(2083) DEFAULT NULL,
+  `url3` VARCHAR(2083) DEFAULT NULL,
+  `url4` VARCHAR(2083) DEFAULT NULL,
+  `mainimageid` BIGINT UNSIGNED DEFAULT NULL,
+  `otherimageids` VARCHAR(255) DEFAULT NULL,
+  `waitlistavailable` TINYINT(1) NOT NULL DEFAULT 0,
+  `waitlist_id` BIGINT UNSIGNED NOT NULL,
+  `page_id` BIGINT UNSIGNED NOT NULL,
+  `ticket_id` BIGINT UNSIGNED NOT NULL,
+  `discountcode` TEXT,
+  `all_day_event` TINYINT(1) NOT NULL DEFAULT 0,
+  `virtual_event` TINYINT(1) NOT NULL DEFAULT 0,
+  `refundsavailable` TINYINT(1) NOT NULL DEFAULT 0,
+  `created_at` DATETIME NOT NULL,
+  `updated_at` DATETIME NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Populate tta_tickets
+INSERT INTO `wp_j9bzlz98u3_tta_tickets`
+  (`id`, `event_ute_id`, `event_name`, `ticket_name`, `waitlist_id`, `ticketlimit`, `baseeventcost`, `discountedmembercost`, `premiummembercost`)
+VALUES
+  (8, 'tte_6852c9ecec0713.67263231', 'New Member Dinner at Tres Machos', 'General Admission', 8, 15, 20.00, 15.00, 10.00),
+  (9, 'tte_68554e50b4e3b2.57528002', 'Buffet & Besties at King\u2019s Korner', 'General Admission', 9, 12,  0.00,  0.00,  0.00),
+  (10,'tte_68554f6943c920.35289009', 'Roller Skating',               'General Admission',10, 30, 12.00, 10.00,  8.00);
+
+-- Populate tta_events
+INSERT INTO `wp_j9bzlz98u3_tta_events`
+  (`id`, `ute_id`, `name`, `date`,       `baseeventcost`, `discountedmembercost`, `premiummembercost`,
+   `address`,                                      `type`,    `time`,        `venuename`, `venueurl`,                                                   `url2`,                                                        `url3`,                                                                 `url4`,                                                                `mainimageid`, `otherimageids`,        `waitlistavailable`, `waitlist_id`, `page_id`, `ticket_id`, `discountcode`,                                            `all_day_event`, `virtual_event`, `refundsavailable`, `created_at`,           `updated_at`)
+VALUES
+  (3,  'tte_6852c9ecec0713.67263231', 'New Member Dinner at Tres Machos','2025-06-30', 20.00,            15.00,                10.00,
+       '2313 Westwood Ave -  - Richmond - Virginia - 23230',       'free',  '18:00|20:00','Tres Machos', 'http://www.tresmachos.com/',                                 'https://www.yelp.com/biz/tres-machos-richmond-3',           'https://www.tripadvisor.com/Restaurant_Review-g60893-d15708234-Reviews-Tres_Machos-Richmond_Virginia.html', 'https://www.instagram.com/tresmachos.glenallen/?hl=en', 19338,          '18705,18714,18857', 1,                   8,           22018,        8,            '{"code":"Discount10Percent","type":"percent","amount":10}', 0,               0,               1,             '2025-06-18 10:15:08', '2025-06-20 07:59:04'),
+  (4,  'tte_68554e50b4e3b2.57528002', 'Buffet & Besties at King\u2019s Korner','2025-07-11',  0.00,             0.00,                 0.00,
+       '7511 Airfield Dr -  - North Chesterfield - Virginia - 23237','paid',  '18:30|20:30','King\'s Korner Catering and Restaurant','https://www.kingskornercatering.com/?utm_source=google&utm_medium=organic&utm_campaign=gmb_profile','https://www.facebook.com/kingskornercatering/','https://www.yelp.com/biz/kings-korner-catering-and-restaurant-north-chesterfield','https://www.tripadvisor.com/Restaurant_Review-g60893-d395520-Reviews-King_s_Korner_Restaurant-Richmond_Virginia.html',22021,'22022,22023,22024,22025',1,9,22026,9,'',0,0,0,'2025-06-20 08:04:32','2025-06-20 08:04:32'),
+  (5,  'tte_68554f6943c920.35289009', 'Roller Skating',                    '2025-07-09', 12.00,            10.00,                 8.00,
+       '4902 Williamsburg Rd -  - Richmond - Virginia - 23231',   'paid',  '19:30|21:30','Rollerdome',  'http://www.rollerdomeskating.com/',                      'https://www.facebook.com/RollerdomeSkating/','https://www.yelp.com/biz/roller-dome-richmond',                'https://www.instagram.com/explore/locations/9273866/rollerdome-skating/?hl=en',22028,'22029,22030,22031,22032,22033,22034',1,10,22035,10,'{"code":"2OffSpecial","type":"flat","amount":2}',0,0,1,'2025-06-20 08:09:13','2025-06-20 08:09:13');
+
+-- Re-enable foreign key checks
+SET FOREIGN_KEY_CHECKS = 1;
+```

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -20,13 +20,7 @@ Returned array keys:
 
 ## Message Center
 
-The Event Page template now includes a **Message Center** block under the “About This Event” section. When the visitor is not logged in the following notice appears:
-
-```
-Ticket discounts may be available! Log in here to check. Don't have an account? Create one here.
-```
-
-Links direct to the standard WordPress login and registration pages. The block is hidden entirely for logged-in users or when no messages apply.
+The Event Page template includes a **Message Center** block under the “About This Event” section. When a visitor is not logged in a small callout invites them to authenticate. Clicking **Log in here** expands an embedded login form with the same accordion animation used elsewhere on the page. The form submits via `wp_login_form()` and redirects back to the event page on success. A link to the standard registration page is also provided.
 
 ## Event Type and Ticket Context
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -26,4 +26,10 @@ The Event Page template includes a **Message Center** block under the “About T
 
 The **Event Details** sidebar now lists the event type (Open Event, Basic Membership Required, or Premium Membership Required). A short message under the “Get Your Tickets Now” heading communicates the membership requirement and offers login or upgrade links depending on the visitor’s status.
 
+## Your Events Sidebar Section
+
+Between the Venue Links and Refund Policy sections a new **Your Events** block appears. When not logged in it shows a single link prompting visitors to log in. Clicking the link scrolls to the Message Center and automatically expands the login form.
+
+Logged-in members instead see links to profile info, upcoming events, past events, and membership/billing details. Each link loads the Member Dashboard with the matching tab active. A log out link is also provided which returns the user to the same event page after signing out.
+
 

--- a/docs/TestingInformation.md
+++ b/docs/TestingInformation.md
@@ -1,0 +1,31 @@
+# Testing Information
+
+This document summarizes test accounts and card numbers used for local development of the Trying To Adult Management Plugin. The data below is provided by Authorize.Net for sandbox use only.
+
+## Test Members
+
+| Membership Level | Member Type | Name            | Email                    | Password                 |
+|------------------|-------------|-----------------|--------------------------|--------------------------|
+| Basic            | Member      | Stacy Harper    | tilypoquh@mailinator.com | ##ALNEE#DLI)wZHvOp14A8Tp |
+| Premium          | Member      | Tucker Copeland | sicuzymyt@mailinator.com | ^$^^6@TyiDpiL72B3rZ7v*tY |
+
+## Authorize.Net Test Credit Card Numbers
+
+The following card numbers are publicly available in the [Authorize.Net testing guide](https://developer.authorize.net/hello_world/testing_guide.html). They will only work in sandbox mode. Use any expiration date after today's date. For the card code, use any three digits (or four digits for American Express).
+
+| Card Brand | Number |
+|------------|-------------------|
+| American Express | 370000000000002 |
+| China UnionPay | 6221499053360818 |
+| China UnionPay | 6262320002000067 |
+| China UnionPay | 6284480000000008 |
+| Discover | 6011000000000012 |
+| JCB | 3088000000000017 |
+| Diners Club / Carte Blanche | 38000000000006 |
+| Visa | 4007000000027 |
+| Visa | 4012888818888 |
+| Visa | 4111111111111111 |
+| Mastercard | 5424000000000015 |
+| Mastercard | 2223000010309703 |
+| Mastercard | 2223000010309711 |
+

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -419,18 +419,32 @@ if ( $ticket_count > 1 ) {
       <?php endif; ?>
 
       <?php if ( ! $is_logged_in ) : ?>
-        <section class="tta-message-center">
-          <p>
-            <?php
-            printf(
-                esc_html__( 'Ticket discounts may be available! %1$sLog in here%2$s to check. Don\'t have an account? %3$sCreate one here%4$s.', 'tta' ),
-                '<a href="' . esc_url( wp_login_url( get_permalink() ) ) . '">',
-                '</a>',
+        <section class="tta-message-center tta-login-accordion">
+          <div class="tta-accordion">
+            <p>
+              <?php
+              printf(
+                /* translators: 1: opening login button, 2: closing login button, 3: opening registration link, 4: closing registration link */
+                esc_html__( 'Ticket discounts may be available! %1$s to check. Don\'t have an account? %3$sCreate one here%4$s.', 'tta' ),
+                '<button type="button" class="tta-button-link tta-accordion-toggle-login">' . esc_html__( 'Log in here', 'tta' ) . '</button>',
+                '',
                 '<a href="' . esc_url( wp_registration_url() ) . '">',
                 '</a>'
-            );
-            ?>
-          </p>
+              );
+              ?>
+            </p>
+            <div class="tta-accordion-content">
+              <?php
+              wp_login_form(
+                [
+                  'echo'     => true,
+                  'redirect' => get_permalink(),
+                  'remember' => true,
+                ]
+              );
+              ?>
+            </div>
+          </div>
         </section>
       <?php endif; ?>
 

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -419,7 +419,7 @@ if ( $ticket_count > 1 ) {
       <?php endif; ?>
 
       <?php if ( ! $is_logged_in ) : ?>
-        <section class="tta-message-center tta-login-accordion">
+        <section id="tta-login-message" class="tta-message-center tta-login-accordion">
           <div class="tta-accordion">
             <p>
               <?php
@@ -718,9 +718,46 @@ if ( $ticket_count > 1 ) {
                     </a>
                   <?php endforeach; ?>
                 </div>
-              </section>
-            </li>
-          <?php endif; ?>
+          </section>
+        </li>
+      <?php endif; ?>
+
+          <li>
+            <section class="tta-event-section tta-your-events">
+              <h2 class="tta-eventpage-sidebar-heading"><?php esc_html_e( 'Your Events', 'tta' ); ?></h2>
+              <ul class="tta-your-events-list">
+              <?php if ( ! $is_logged_in ) : ?>
+                <li>
+                  <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/login.svg' ); ?>" alt="<?php esc_attr_e( 'Login', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after">
+                    <a href="#tta-login-message" class="tta-scroll-login"><?php esc_html_e( 'Login to see info about your events', 'tta' ); ?></a>
+                  </div>
+                </li>
+              <?php else : ?>
+                <li>
+                  <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Profile', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-profile' ) ); ?>" class="tta-dashboard-link" data-tab="profile"><?php esc_html_e( 'Your Profile Info', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                  <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt="<?php esc_attr_e( 'Upcoming', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-upcoming' ) ); ?>" class="tta-dashboard-link" data-tab="upcoming"><?php esc_html_e( 'Your Upcoming Events', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                  <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/past.svg' ); ?>" alt="<?php esc_attr_e( 'Past', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-past' ) ); ?>" class="tta-dashboard-link" data-tab="past"><?php esc_html_e( 'Your Past Events', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                  <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/billing.svg' ); ?>" alt="<?php esc_attr_e( 'Billing', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-billing' ) ); ?>" class="tta-dashboard-link" data-tab="billing"><?php esc_html_e( 'Membership Details', 'tta' ); ?></a></div>
+                </li>
+                <li>
+                  <img class="tta-event-details-icon logout-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/login.svg' ); ?>" alt="<?php esc_attr_e( 'Log out', 'tta' ); ?>">
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( wp_logout_url( get_permalink() ) ); ?>"><?php esc_html_e( 'Log out', 'tta' ); ?></a></div>
+                </li>
+              <?php endif; ?>
+              </ul>
+            </section>
+          </li>
 
 
 


### PR DESCRIPTION
## Summary
- document SQL snippets for populating local tables with demo data
- mention the new database snippets doc in README
- embed login accordion in message center when viewing events while logged out

## Testing
- `composer install`
- `php vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68554a12f778832091ec707052381e4f