### PR TITLE
Fix login scroll handler

### DIFF
--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -59,7 +59,7 @@ jQuery(function($){
         $('html, body').animate({
           scrollTop: target.offset().top - getHeaderHeight() - extraOffset
         }, 600, function(){
-          target.find('.tta-accordion-toggle-login').trigger('click');
+          $('.tta-message-center .tta-button-link').trigger('click');
         });
       }
     });

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -51,18 +51,18 @@ jQuery(function($){
         }, 600);
       }
     });
-  });
 
-  $('.tta-scroll-login').on('click', function(e){
-    e.preventDefault();
-    var target = $('#tta-login-message');
-    if ( target.length ) {
-      $('html, body').animate({
-        scrollTop: target.offset().top - getHeaderHeight() - extraOffset
-      }, 600, function(){
-        target.find('.tta-accordion-toggle-login').trigger('click');
-      });
-    }
+    $('.tta-scroll-login').on('click', function(e){
+      e.preventDefault();
+      var target = $('#tta-login-message');
+      if ( target.length ) {
+        $('html, body').animate({
+          scrollTop: target.offset().top - getHeaderHeight() - extraOffset
+        }, 600, function(){
+          target.find('.tta-accordion-toggle-login').trigger('click');
+        });
+      }
+    });
   });
 })(jQuery);
 

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -55,12 +55,11 @@ jQuery(function($){
     $('.tta-scroll-login').on('click', function(e){
       e.preventDefault();
       var target = $('#tta-login-message');
+      $('.tta-message-center .tta-accordion-content').addClass('expanded');
       if ( target.length ) {
         $('html, body').animate({
           scrollTop: target.offset().top - getHeaderHeight() - extraOffset
-        }, 600, function(){
-          $('.tta-message-center .tta-button-link').trigger('click');
-        });
+        }, 600);
       }
     });
   });

--- a/assets/js/frontend/event-page.js
+++ b/assets/js/frontend/event-page.js
@@ -34,18 +34,20 @@ jQuery(function($){
 
 
 (function($){
-  $(function(){
-    // adjust this selector to match your fixed header
-    var headerSelector = '.site-header, .tta-header'; 
-    var headerHeight   = $(headerSelector).first().outerHeight() || 0;
-    var extraOffset    = 200; // extra space below header
+  var headerSelector = '.site-header, .tta-header';
+  var extraOffset    = 200; // extra space below header
 
-  $('a[href="#tta-event-buy"]').on('click', function(e){
+  function getHeaderHeight(){
+    return $(headerSelector).first().outerHeight() || 0;
+  }
+
+  $(function(){
+    $('a[href="#tta-event-buy"]').on('click', function(e){
       e.preventDefault();
       var target = $('#tta-event-buy');
       if ( target.length ) {
         $('html, body').animate({
-          scrollTop: target.offset().top - headerHeight - extraOffset
+          scrollTop: target.offset().top - getHeaderHeight() - extraOffset
         }, 600);
       }
     });
@@ -56,7 +58,7 @@ jQuery(function($){
     var target = $('#tta-login-message');
     if ( target.length ) {
       $('html, body').animate({
-        scrollTop: target.offset().top - headerHeight - extraOffset
+        scrollTop: target.offset().top - getHeaderHeight() - extraOffset
       }, 600, function(){
         target.find('.tta-accordion-toggle-login').trigger('click');
       });
@@ -93,16 +95,12 @@ $(document).on('change', '.tta-qty-input', enforceLimit);
 jQuery(function($){
   $('.tta-accordion-toggle-login').on('click', function(){
     var $btn  = $(this),
-        $cont = $btn.closest('.tta-accordion').find('.tta-accordion-content'),
-        loginText = 'Log in here',
-        hideText  = 'Hide login';
+        $cont = $btn.closest('.tta-accordion').find('.tta-accordion-content');
 
     if ( $cont.hasClass('expanded') ) {
       $cont.removeClass('expanded');
-      $btn.text( loginText );
     } else {
       $cont.addClass('expanded');
-      $btn.text( hideText );
     }
   });
 });

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -29,6 +29,7 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 ## Your Events Sidebar Section
 
 Between the Venue Links and Refund Policy sections a new **Your Events** block appears. When not logged in it shows a single link prompting visitors to log in. Clicking the link scrolls to the Message Center and automatically expands the login form.
+The scroll handler triggers the same click event used by the login button to ensure the form is revealed.
 The toggle button text remains **Log in here** even after the form expands so the call to action stays consistent.
 Scrolling accounts for any fixed header on the site. Adjust the selector in `event-page.js` if your theme uses a different header structure.
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -29,7 +29,7 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 ## Your Events Sidebar Section
 
 Between the Venue Links and Refund Policy sections a new **Your Events** block appears. When not logged in it shows a single link prompting visitors to log in. Clicking the link scrolls to the Message Center and automatically expands the login form.
-The scroll handler triggers the same click event used by the login button to ensure the form is revealed.
+Login expansion happens directly by adding the `expanded` class so the form is open immediately.
 The toggle button text remains **Log in here** even after the form expands so the call to action stays consistent.
 Scrolling accounts for any fixed header on the site. Adjust the selector in `event-page.js` if your theme uses a different header structure.
 

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -29,6 +29,8 @@ The **Event Details** sidebar now lists the event type (Open Event, Basic Member
 ## Your Events Sidebar Section
 
 Between the Venue Links and Refund Policy sections a new **Your Events** block appears. When not logged in it shows a single link prompting visitors to log in. Clicking the link scrolls to the Message Center and automatically expands the login form.
+The toggle button text remains **Log in here** even after the form expands so the call to action stays consistent.
+Scrolling accounts for any fixed header on the site. Adjust the selector in `event-page.js` if your theme uses a different header structure.
 
 Logged-in members instead see links to profile info, upcoming events, past events, and membership/billing details. Each link loads the Member Dashboard with the matching tab active. A log out link is also provided which returns the user to the same event page after signing out.
 


### PR DESCRIPTION
## Summary
- keep `Log in here` text constant when toggling login form
- ensure `Login to see info about your events` link scrolls correctly

## Testing
- `composer install`
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6855606b6aac8320857189204b4ab4bd