### PR TITLE
Add event archiving to keep events table lean

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Operator Testing Guide](docs/OperatorTestingGuide.md)
 - [Project TODOs](TODO.md)
 
+Old events are automatically moved to an `tta_events_archive` table by a daily cron. The process is transparent to admins and members.
+Whenever the structure of `tta_events` changes, mirror those updates to `tta_events_archive` as well.
+
 ## Running Tests
 
 After installing PHP and Composer, execute `composer install` followed by

--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,5 @@ A running list of tasks and reminders for future development.
 - [ ] Create a referral program page (`/referral-program`) and implement a one-time referral discount code that can be applied to any event.
 - [ ] Move Authorize.Net credentials out of `authnet-config.php` before deploying to production.
 - [ ] Implement sending logic for the Email & SMS templates and handle token replacement.
+- [ ] Ensure internal links use relative URLs so deployments work across domains.
+- [ ] Keep `tta_events_archive` schema in sync with `tta_events` whenever changes are made.

--- a/assets/css/backend/admin.css
+++ b/assets/css/backend/admin.css
@@ -452,3 +452,7 @@ form p.submit{
 .tta-sms-count.tta-over-limit {
   color:#b32d2e;
 }
+
+.tta-token-section {
+  margin-bottom:8px;
+}

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -956,20 +956,34 @@ jQuery(function($){
     var body = $form.find('textarea[name=email_body]').val() || '';
     var sms  = $form.find('textarea[name=sms_text]').val() || '';
     var ev   = TTA_Ajax.sample_event || {};
+    var mem  = TTA_Ajax.sample_member || {};
     var map  = {
-      '{event_name}': ev.name || 'Sample Event',
-      '{event_address}': ev.address || '123 Main St',
-      '{event_link}': ev.page_url || '#',
-      '{dashboard_link}': ev.dashboard_url || '#',
-      '{event_date}': ev.date || '2025-01-01',
-      '{event_time}': ev.time || '00:00',
-      '{event_type}': ev.type || 'Open',
-      '{venue_name}': ev.venue_name || 'Venue',
-      '{venue_url}': ev.venue_url || '#',
-      '{base_cost}': ev.base_cost || '0',
-      '{member_cost}': ev.member_cost || '0',
-      '{premium_cost}': ev.premium_cost || '0'
-    };
+        '{event_name}': ev.name || 'Sample Event',
+        '{event_address}': ev.address || '123 Main St',
+        '{event_link}': ev.page_url || '#',
+        '{dashboard_profile_url}': ev.dashboard_profile_url || '#',
+        '{dashboard_upcoming_url}': ev.dashboard_upcoming_url || '#',
+        '{dashboard_past_url}': ev.dashboard_past_url || '#',
+        '{dashboard_billing_url}': ev.dashboard_billing_url || '#',
+        '{event_date}': ev.date || '2025-01-01',
+        '{event_time}': ev.time || '00:00',
+        '{event_type}': ev.type || 'Open',
+        '{venue_name}': ev.venue_name || 'Venue',
+        '{venue_url}': ev.venue_url || '#',
+        '{base_cost}': ev.base_cost || '0',
+        '{member_cost}': ev.member_cost || '0',
+        '{premium_cost}': ev.premium_cost || '0',
+        '{first_name}': mem.first_name || 'First',
+        '{last_name}': mem.last_name || 'Last',
+        '{email}': mem.email || 'member@example.com',
+        '{phone}': mem.phone || '555-555-5555',
+        '{membership_level}': mem.membership_level || 'basic',
+        '{member_type}': mem.member_type || 'member',
+        '{attendee_first_name}': mem.first_name || 'First',
+        '{attendee_last_name}': mem.last_name || 'Last',
+        '{attendee_email}': mem.email || 'attendee@example.com',
+        '{attendee_phone}': mem.phone || '555-555-5555'
+      };
     Object.keys(map).forEach(function(tok){
       var val = map[tok];
       subj = subj.split(tok).join(val);

--- a/assets/js/frontend/event-checkin.js
+++ b/assets/js/frontend/event-checkin.js
@@ -1,0 +1,30 @@
+jQuery(function($){
+  // Toggle event rows
+  $(document).on('click', '.tta-event-row', function(e){
+    if ($(e.target).is('button, a, img')) return;
+    var $row = $(this), ute = $row.data('event-ute-id'),
+        $ex = $row.next('.tta-inline-row');
+    if ($ex.length){
+      $ex.remove();
+      return;
+    }
+    $('.tta-inline-row').remove();
+    $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
+      if(!res.success) return;
+      var colspan = $row.find('td').length;
+      var $new = $('<tr class="tta-inline-row"><td colspan="'+colspan+'">'+res.data.html+'</td></tr>');
+      $row.after($new);
+    }, 'json');
+  });
+
+  // Set attendance status
+  $(document).on('click', '.tta-mark-attendance', function(e){
+    e.preventDefault();
+    var $btn = $(this), id = $btn.data('attendee-id'), status = $btn.data('status');
+    $.post(TTA_Checkin.ajax_url, { action:'tta_set_attendance', nonce:TTA_Checkin.set_nonce, attendee_id:id, status:status }, function(res){
+      if(!res.success) return;
+      var label = $btn.closest('tr').find('.status-label');
+      label.text(status.replace('_',' ').toUpperCase());
+    }, 'json');
+  });
+});

--- a/assets/js/frontend/member-dashboard.js
+++ b/assets/js/frontend/member-dashboard.js
@@ -26,13 +26,26 @@ jQuery(function($){
     $('#tab-' + tab).show();
   });
 
-  // Activate tab based on URL hash
-  var hashTab = window.location.hash.replace('#tab-', '');
-  if ( hashTab ) {
-    var $trigger = $('.tta-dashboard-tabs li[data-tab="' + hashTab + '"]');
-    if ( $trigger.length ) {
+  // Activate tab based on URL hash or ?tab=name parameter
+  function activateTab(tab){
+    var $trigger = $('.tta-dashboard-tabs li[data-tab="' + tab + '"]');
+    if ($trigger.length) {
       $trigger.trigger('click');
+      // scroll to the dashboard area after activating
+      var $wrap = $('.tta-member-dashboard-wrap');
+      var h = $('.site-header, .tta-header').first().outerHeight() || 0;
+      $('html, body').animate({
+        scrollTop: $wrap.offset().top - h - 100
+      }, 600);
     }
+  }
+
+  var urlParams = new URLSearchParams(window.location.search);
+  var paramTab = urlParams.get('tab');
+  var hashTab = window.location.hash.replace('#tab-', '');
+  var active = paramTab || hashTab;
+  if (active) {
+    activateTab(active);
   }
 
   // 3) Add/remove interests

--- a/docs/DevelopmentSQL.md
+++ b/docs/DevelopmentSQL.md
@@ -131,6 +131,9 @@ CREATE TABLE `wp_j9bzlz98u3_tta_events` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- Re-create tta_events_archive (same structure as tta_events)
+CREATE TABLE `wp_j9bzlz98u3_tta_events_archive` LIKE `wp_j9bzlz98u3_tta_events`;
+
 -- Populate tta_tickets
 INSERT INTO `wp_j9bzlz98u3_tta_tickets`
   (`id`, `event_ute_id`, `event_name`, `ticket_name`, `waitlist_id`, `ticketlimit`, `baseeventcost`, `discountedmembercost`, `premiummembercost`)
@@ -193,4 +196,13 @@ Version 1.1.0 adds an `is_member` column to `tta_attendees`. Existing installs w
 ```sql
 ALTER TABLE `wp_j9bzlz98u3_tta_attendees`
   ADD COLUMN `is_member` TINYINT(1) DEFAULT 0;
+```
+
+## Track attendance check-in status
+
+Version 1.2.0 introduces an `status` column on `tta_attendees` to record whether each attendee was checked in or marked a no-show. Existing installs will add the column automatically, or you can run:
+
+```sql
+ALTER TABLE `wp_j9bzlz98u3_tta_attendees`
+  ADD COLUMN `status` ENUM('pending','checked_in','no_show') DEFAULT 'pending';
 ```

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -9,6 +9,13 @@ The plugin sends automated notifications to members. Administrators can edit the
 | `purchase` | Sent after a successful event purchase. Includes event details automatically. |
 | `reminder_24hr` | Sent 24 hours before an event starts. |
 | `reminder_2hr` | Sent two hours before an event starts. |
+| `new_event` | Internal notice when a new event is created. |
+| `refund_requested` | Internal notice when a member requests a refund. |
+| `event_sold_out` | Internal alert when an event reaches capacity. |
+| `host_reminder_24hr` | Reminder to event hosts 24 hours before their event. |
+| `host_reminder_2hr` | Reminder to event hosts two hours before their event. |
+| `volunteer_reminder_24hr` | Reminder to volunteers 24 hours before their event. |
+| `volunteer_reminder_2hr` | Reminder to volunteers two hours before their event. |
 
 Each template stores:
 
@@ -25,8 +32,10 @@ Default values are provided on initial install:
 - **Purchase SMS**: "Thanks for registering! View your upcoming events at "
 - **24-Hour Reminder Email Body**: "Heads-up! Your event is just 1 day away! Below are the details."
 - **2-Hour Reminder Email Body**: "Your event is only 2 hours away! Below are the details."
+- **Admin Notifications**: emails are sent when new events are created, refunds are requested or events sell out.
+- **Host and Volunteer Reminders**: internal messages mirror attendee reminders at 24 and 2 hours before the event.
 
-The member dashboard link appended to SMS messages uses a short URL when possible.
+Links to the member dashboard are relative URLs so they work on any domain. Tokens include direct links to each dashboard tab.
 
 ## Previews and Tokens
 
@@ -36,11 +45,16 @@ SMS previews show a character count. If the text exceeds 160 characters the coun
 
 Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the last focused field. The sending logic will replace these tokens with real data. Available tokens include:
 
+### Event Information
+
 ```
 {event_name}
 {event_address}
 {event_link}
-{dashboard_link}
+{dashboard_profile_url}
+{dashboard_upcoming_url}
+{dashboard_past_url}
+{dashboard_billing_url}
 {event_date}
 {event_time}
 {event_type}
@@ -49,6 +63,26 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 {base_cost}
 {member_cost}
 {premium_cost}
+```
+
+### Member Information
+
+```
+{first_name}
+{last_name}
+{email}
+{phone}
+{membership_level}
+{member_type}
+```
+
+### Event Attendee Information
+
+```
+{attendee_first_name}
+{attendee_last_name}
+{attendee_email}
+{attendee_phone}
 ```
 
 Use the **Line Break** button to insert a newline. Email previews render these breaks as HTML `<br>` tags so the saved text remains plain.

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -20,3 +20,7 @@ Events are loaded chronologically and the layout supports any number of events.
 Attendee details are pulled from the transaction history and stored in the
 `tta_attendees` table.
 Event thumbnails use the medium image size and are scaled to a consistent width so nothing is cropped.
+
+## Past Events Tab
+
+Past events show the same details as upcoming events. To keep the database small, events more than three days past are moved to an `tta_events_archive` table by a daily cron job. The dashboard transparently queries both the current events table and this archive so members can always view their history.

--- a/includes/admin/class-comms-admin.php
+++ b/includes/admin/class-comms-admin.php
@@ -20,28 +20,94 @@ class TTA_Comms_Admin {
     public static function get_default_templates(){
         return [
             'purchase' => [
-                'label'    => __('Successful Event Purchase', 'tta'),
-                'type'     => 'External',
-                'category' => 'Event Confirmation',
+                'label'       => __('Successful Event Purchase', 'tta'),
+                'type'        => 'External',
+                'category'    => 'Event Confirmation',
+                'description' => __('Sent after a member buys tickets to an event.', 'tta'),
                 'email_subject' => __('Thanks for Registering!', 'tta'),
-                'email_body' => __("You're in! Thank for registering for our upcoming Trying To Adult event. The details of the event are below. Please keep this email, as you'll need to present this to the Event Host or Volunteer when arriving at your event.", 'tta'),
-                'sms_text' => __('Thanks for registering! View your upcoming events at ', 'tta'),
+                'email_body'  => __("You're in! Thank for registering for our upcoming Trying To Adult event. The details of the event are below. Please keep this email, as you'll need to present this to the Event Host or Volunteer when arriving at your event.", 'tta'),
+                'sms_text'    => __('Thanks for registering! View your upcoming events at ', 'tta'),
             ],
             'reminder_24hr' => [
-                'label'    => __('24-Hour Event Reminder', 'tta'),
-                'type'     => 'External',
-                'category' => 'Event Reminder',
+                'label'       => __('24-Hour Event Reminder', 'tta'),
+                'type'        => 'External',
+                'category'    => 'Event Reminder',
+                'description' => __('Reminder email to attendees one day before the event.', 'tta'),
                 'email_subject' => __('Your event is tomorrow!', 'tta'),
-                'email_body' => __('Heads-up! Your event is just 1 day away! Below are the details.', 'tta'),
-                'sms_text' => __('Heads-Up! your event is tomorrow! View your upcoming events at ', 'tta'),
+                'email_body'  => __('Heads-up! Your event is just 1 day away! Below are the details.', 'tta'),
+                'sms_text'    => __('Heads-Up! your event is tomorrow! View your upcoming events at ', 'tta'),
             ],
             'reminder_2hr' => [
-                'label'    => __('2-Hour Event Reminder', 'tta'),
-                'type'     => 'External',
-                'category' => 'Event Reminder',
+                'label'       => __('2-Hour Event Reminder', 'tta'),
+                'type'        => 'External',
+                'category'    => 'Event Reminder',
+                'description' => __('Reminder email to attendees two hours before the event.', 'tta'),
                 'email_subject' => __('Event starting soon!', 'tta'),
-                'email_body' => __('Your event is only 2 hours away! Below are the details.', 'tta'),
-                'sms_text' => __('Only 2 hours to go! View your upcoming events at ', 'tta'),
+                'email_body'  => __('Your event is only 2 hours away! Below are the details.', 'tta'),
+                'sms_text'    => __('Only 2 hours to go! View your upcoming events at ', 'tta'),
+            ],
+            'new_event' => [
+                'label'       => __('New Event Created', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Admin Notice',
+                'description' => __('Notifies administrators when a new event is created.', 'tta'),
+                'email_subject' => __('New event created', 'tta'),
+                'email_body'  => __('A new event has been added to the calendar. Details are below.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'refund_requested' => [
+                'label'       => __('Refund Requested', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Admin Notice',
+                'description' => __('Alert when a member requests a refund.', 'tta'),
+                'email_subject' => __('Refund request received', 'tta'),
+                'email_body'  => __('A member has requested a refund for the event below.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'event_sold_out' => [
+                'label'       => __('Event Sold Out', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Admin Notice',
+                'description' => __('Alert when an event reaches capacity.', 'tta'),
+                'email_subject' => __('Event has sold out', 'tta'),
+                'email_body'  => __('The following event is now sold out.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'host_reminder_24hr' => [
+                'label'       => __('Host Reminder 24hr', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Host Reminder',
+                'description' => __('Reminder to event hosts one day before the event.', 'tta'),
+                'email_subject' => __('You are hosting tomorrow', 'tta'),
+                'email_body'  => __('Friendly reminder that you are hosting an event in 24 hours. Details are below.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'host_reminder_2hr' => [
+                'label'       => __('Host Reminder 2hr', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Host Reminder',
+                'description' => __('Reminder to event hosts two hours before the event.', 'tta'),
+                'email_subject' => __('Hosting duty soon', 'tta'),
+                'email_body'  => __('Your hosting duties begin in two hours. See the event details below.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'volunteer_reminder_24hr' => [
+                'label'       => __('Volunteer Reminder 24hr', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Volunteer Reminder',
+                'description' => __('Reminder to volunteers one day before the event.', 'tta'),
+                'email_subject' => __('You are volunteering tomorrow', 'tta'),
+                'email_body'  => __('This is a reminder that you volunteered for an event in 24 hours. Details are below.', 'tta'),
+                'sms_text'    => '',
+            ],
+            'volunteer_reminder_2hr' => [
+                'label'       => __('Volunteer Reminder 2hr', 'tta'),
+                'type'        => 'Internal',
+                'category'    => 'Volunteer Reminder',
+                'description' => __('Reminder to volunteers two hours before the event.', 'tta'),
+                'email_subject' => __('Volunteer duty soon', 'tta'),
+                'email_body'  => __('Your volunteer shift begins in two hours. Event details are below.', 'tta'),
+                'sms_text'    => '',
             ],
         ];
     }
@@ -95,15 +161,23 @@ class TTA_Comms_Admin {
             echo '<form method="post" class="tta-comms-form">';
             wp_nonce_field( 'tta_comms_save_action', 'tta_comms_save_nonce' );
             echo '<input type="hidden" name="template_key" value="'.esc_attr( $key ).'">';
+            if ( ! empty( $vals['description'] ) ) {
+                echo '<p class="description">' . esc_html( $vals['description'] ) . '</p>';
+            }
             echo '<table class="form-table">';
             echo '<tr><th scope="row">' . esc_html__( 'Email Subject', 'tta' ) . '</th><td><input type="text" name="email_subject" value="' . esc_attr( $vals['email_subject'] ) . '" class="regular-text tta-comm-input"></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Email Body', 'tta' ) . '</th><td><textarea name="email_body" rows="4" class="large-text tta-comm-input">' . esc_textarea( $vals['email_body'] ) . '</textarea></td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'SMS Text', 'tta' ) . '</th><td><textarea name="sms_text" rows="2" class="large-text tta-comm-input">' . esc_textarea( $vals['sms_text'] ) . '</textarea><br><span class="tta-sms-count">0</span>/160</td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Insert Token', 'tta' ) . '</th><td>';
+            echo '<div class="tta-token-section"><strong>' . esc_html__( 'Event Information', 'tta' ) . '</strong> ';
+            echo '<span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Details about the event.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span><br>';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_name}">{event_name}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_address}">{event_address}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_link}">{event_link}</button> ';
-            echo '<button type="button" class="button tta-insert-token" data-token="{dashboard_link}">{dashboard_link}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{dashboard_profile_url}">{dashboard_profile_url}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{dashboard_upcoming_url}">{dashboard_upcoming_url}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{dashboard_past_url}">{dashboard_past_url}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{dashboard_billing_url}">{dashboard_billing_url}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_date}">{event_date}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_time}">{event_time}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{event_type}">{event_type}</button> ';
@@ -111,7 +185,24 @@ class TTA_Comms_Admin {
             echo '<button type="button" class="button tta-insert-token" data-token="{venue_url}">{venue_url}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{base_cost}">{base_cost}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{member_cost}">{member_cost}</button> ';
-            echo '<button type="button" class="button tta-insert-token" data-token="{premium_cost}">{premium_cost}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{premium_cost}">{premium_cost}</button></div>';
+
+            echo '<div class="tta-token-section"><strong>' . esc_html__( 'Member Information', 'tta' ) . '</strong> ';
+            echo '<span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Details from the purchasing member profile.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span><br>';
+            echo '<button type="button" class="button tta-insert-token" data-token="{first_name}">{first_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{last_name}">{last_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{email}">{email}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{phone}">{phone}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{membership_level}">{membership_level}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{member_type}">{member_type}</button></div>';
+
+            echo '<div class="tta-token-section"><strong>' . esc_html__( 'Event Attendee Information', 'tta' ) . '</strong> ';
+            echo '<span class="tta-tooltip-icon" data-tooltip="' . esc_attr__( 'Per-ticket attendee details.', 'tta' ) . '"><img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ) . '" alt="?"></span><br>';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_first_name}">{attendee_first_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_last_name}">{attendee_last_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_email}">{attendee_email}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_phone}">{attendee_phone}</button></div>';
+
             echo '<button type="button" class="button tta-insert-br">Line Break</button>';
             echo '</td></tr>';
             echo '<tr><th scope="row">' . esc_html__( 'Email Preview', 'tta' ) . '</th><td><div class="tta-email-preview"><strong class="tta-email-preview-subject"></strong><p class="tta-email-preview-body"></p></div></td></tr>';

--- a/includes/admin/views/events-manage.php
+++ b/includes/admin/views/events-manage.php
@@ -9,13 +9,24 @@ if ( isset( $_GET['action'] ) && $_GET['action'] === 'delete' && isset( $_GET['e
     if ( check_admin_referer( 'tta_event_delete_nonce' ) ) {
         $event_id = intval( $_GET['event_id'] );
 
-        // 1) Fetch the event's unique identifier (ute_id)
-        $ute_id = $wpdb->get_var(
+        // 1) Fetch the full event row
+        $event_row = $wpdb->get_row(
             $wpdb->prepare(
-                "SELECT ute_id FROM {$table} WHERE id = %d",
+                "SELECT * FROM {$table} WHERE id = %d",
                 $event_id
-            )
+            ),
+            ARRAY_A
         );
+        $ute_id = $event_row['ute_id'] ?? null;
+
+        // Archive the event before deleting
+        if ( $event_row ) {
+            $archive_table = $wpdb->prefix . 'tta_events_archive';
+            $exists = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$archive_table} WHERE id = %d", $event_id ) );
+            if ( ! $exists ) {
+                $wpdb->insert( $archive_table, $event_row );
+            }
+        }
 
         if ( $ute_id ) {
             // 2) Delete all waitlists for that event

--- a/includes/ajax/class-ajax-handler.php
+++ b/includes/ajax/class-ajax-handler.php
@@ -10,6 +10,7 @@ require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-tickets.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-cart.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-checkout.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-comms.php';
+require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-attendance.php';
 
 
 // Initialize them
@@ -19,3 +20,4 @@ TTA_Ajax_Tickets::init();
 TTA_Ajax_Cart::init();
 TTA_Ajax_Checkout::init();
 TTA_Ajax_Comms::init();
+TTA_Ajax_Attendance::init();

--- a/includes/ajax/handlers/class-ajax-attendance.php
+++ b/includes/ajax/handlers/class-ajax-attendance.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class TTA_Ajax_Attendance {
+    public static function init() {
+        add_action( 'wp_ajax_tta_get_event_attendance', [ __CLASS__, 'get_event_attendance' ] );
+        add_action( 'wp_ajax_tta_set_attendance', [ __CLASS__, 'set_attendance' ] );
+    }
+
+    public static function get_event_attendance() {
+        check_ajax_referer( 'tta_get_attendance_action', 'nonce' );
+        $ute = tta_sanitize_text_field( $_POST['event_ute_id'] ?? '' );
+        if ( ! $ute ) {
+            wp_send_json_error( [ 'message' => 'missing id' ] );
+        }
+        global $wpdb;
+        $events_table = $wpdb->prefix . 'tta_events';
+        $event = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$events_table} WHERE ute_id = %s", $ute ), ARRAY_A );
+        if ( ! $event ) {
+            wp_send_json_error( [ 'message' => 'not found' ] );
+        }
+        $attendees = tta_get_event_attendees_with_status( $ute );
+        ob_start();
+        $GLOBALS['event'] = $event;
+        $GLOBALS['attendees'] = $attendees;
+        include TTA_PLUGIN_DIR . 'includes/frontend/views/attendance-list.php';
+        $html = ob_get_clean();
+        wp_send_json_success( [ 'html' => $html ] );
+    }
+
+    public static function set_attendance() {
+        check_ajax_referer( 'tta_set_attendance_action', 'nonce' );
+        $att_id = intval( $_POST['attendee_id'] ?? 0 );
+        $status = sanitize_text_field( $_POST['status'] ?? 'pending' );
+        if ( ! $att_id ) {
+            wp_send_json_error( [ 'message' => 'missing attendee' ] );
+        }
+        tta_set_attendance_status( $att_id, $status );
+        wp_send_json_success();
+    }
+}
+
+TTA_Ajax_Attendance::init();

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -64,6 +64,46 @@ class TTA_DB_Setup {
         ) $charset_collate";
 
         // ─────────────────────────────────────────────────────────────────
+        // Events archive table
+        // ─────────────────────────────────────────────────────────────────
+        $sql_statements[] = "
+        CREATE TABLE {$prefix}events_archive (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            ute_id VARCHAR(100) NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            date DATE NOT NULL,
+            baseeventcost DECIMAL(10,2) DEFAULT 0.00,
+            discountedmembercost DECIMAL(10,2) DEFAULT 0.00,
+            premiummembercost DECIMAL(10,2) DEFAULT 0.00,
+            address VARCHAR(500) DEFAULT '',
+            type VARCHAR(50) DEFAULT 'free',
+            time VARCHAR(50) DEFAULT 'N/A',
+            venuename VARCHAR(255) DEFAULT '',
+            venueurl VARCHAR(255) DEFAULT '',
+            url2 VARCHAR(255) DEFAULT '',
+            url3 VARCHAR(255) DEFAULT '',
+            url4 VARCHAR(255) DEFAULT '',
+            mainimageid BIGINT UNSIGNED DEFAULT 0,
+            otherimageids TEXT,
+            waitlistavailable TINYINT(1) DEFAULT 0,
+            waitlist_id BIGINT UNSIGNED DEFAULT 0,
+            page_id BIGINT UNSIGNED DEFAULT 0,
+            ticket_id BIGINT UNSIGNED DEFAULT 0,
+            discountcode VARCHAR(255) DEFAULT '',
+            all_day_event TINYINT(1) DEFAULT 0,
+            virtual_event TINYINT(1) DEFAULT 0,
+            refundsavailable TINYINT(1) DEFAULT 0,
+            hosts TEXT,
+            volunteers TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY ute_id (ute_id),
+            KEY page_id_idx (page_id),
+            KEY date_idx (date)
+        ) $charset_collate";
+
+        // ─────────────────────────────────────────────────────────────────
         // Members table
         // ─────────────────────────────────────────────────────────────────
         $sql_statements[] = "
@@ -227,6 +267,7 @@ class TTA_DB_Setup {
             opt_in_sms      TINYINT(1)     DEFAULT 0,
             opt_in_email    TINYINT(1)     DEFAULT 0,
             is_member       TINYINT(1)     DEFAULT 0,
+            status          ENUM('pending','checked_in','no_show') DEFAULT 'pending',
             PRIMARY KEY     (id),
             KEY transaction_idx (transaction_id),
             KEY ticket_idx      (ticket_id),

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -98,10 +98,14 @@ class TTA_Assets {
                         if ( ! $e ) {
                             return null;
                         }
-                        $e['page_url']       = get_permalink( $e['page_id'] );
-                        $e['dashboard_url']  = site_url( '/member-dashboard/?tab=upcoming' );
+                        $e['page_url']              = get_permalink( $e['page_id'] );
+                        $e['dashboard_profile_url'] = home_url( '/member-dashboard/?tab=profile', 'relative' );
+                        $e['dashboard_upcoming_url'] = home_url( '/member-dashboard/?tab=upcoming', 'relative' );
+                        $e['dashboard_past_url']    = home_url( '/member-dashboard/?tab=past', 'relative' );
+                        $e['dashboard_billing_url'] = home_url( '/member-dashboard/?tab=billing', 'relative' );
                         return $e;
                     } )(),
+                    'sample_member'       => tta_get_sample_member(),
                 ]
             );
         }
@@ -238,6 +242,26 @@ class TTA_Assets {
                 [
                     'ajax_url' => admin_url( 'admin-ajax.php' ),
                     'nonce'    => wp_create_nonce( 'tta_checkout_action' ),
+                ]
+            );
+        }
+
+        // 5) Host Check-In template assets
+        if ( function_exists( 'is_page_template' ) && is_page_template( 'host-checkin-template.php' ) ) {
+            wp_enqueue_script(
+                'tta-checkin-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/event-checkin.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
+            wp_localize_script(
+                'tta-checkin-js',
+                'TTA_Checkin',
+                [
+                    'ajax_url'  => admin_url( 'admin-ajax.php' ),
+                    'get_nonce' => wp_create_nonce( 'tta_get_attendance_action' ),
+                    'set_nonce' => wp_create_nonce( 'tta_set_attendance_action' ),
                 ]
             );
         }

--- a/includes/classes/class-tta-event-archiver.php
+++ b/includes/classes/class-tta-event-archiver.php
@@ -1,0 +1,52 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class TTA_Event_Archiver {
+    /**
+     * Archive and remove past events older than three days.
+     */
+    public static function archive_past_events() {
+        global $wpdb;
+        $events_table  = $wpdb->prefix . 'tta_events';
+        $archive_table = $wpdb->prefix . 'tta_events_archive';
+        $waitlist_table= $wpdb->prefix . 'tta_waitlist';
+        $tickets_table = $wpdb->prefix . 'tta_tickets';
+
+        $cutoff = date( 'Y-m-d', strtotime( '-3 days', current_time( 'timestamp' ) ) );
+        $rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$events_table} WHERE date < %s", $cutoff ), ARRAY_A );
+
+        foreach ( $rows as $row ) {
+            $id     = intval( $row['id'] );
+            $ute_id = $row['ute_id'];
+            $exists = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$archive_table} WHERE id = %d", $id ) );
+            if ( ! $exists ) {
+                $wpdb->insert( $archive_table, $row );
+            }
+            $wpdb->delete( $waitlist_table, [ 'event_ute_id' => $ute_id ], [ '%s' ] );
+            $wpdb->delete( $tickets_table,  [ 'event_ute_id' => $ute_id ], [ '%s' ] );
+            $wpdb->delete( $events_table,  [ 'id' => $id ], [ '%d' ] );
+        }
+
+        if ( ! empty( $rows ) ) {
+            TTA_Cache::flush();
+        }
+    }
+
+    /** Schedule the cron event. */
+    public static function schedule_event() {
+        if ( ! wp_next_scheduled( 'tta_event_archive_event' ) ) {
+            wp_schedule_event( time(), 'daily', 'tta_event_archive_event' );
+        }
+    }
+
+    /** Clear the scheduled cron event. */
+    public static function clear_event() {
+        wp_clear_scheduled_hook( 'tta_event_archive_event' );
+    }
+
+    /** Initialize hooks. */
+    public static function init() {
+        add_action( 'tta_event_archive_event', [ __CLASS__, 'archive_past_events' ] );
+        self::schedule_event();
+    }
+}

--- a/includes/frontend/class-tta-checkin-page-manager.php
+++ b/includes/frontend/class-tta-checkin-page-manager.php
@@ -1,0 +1,30 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class TTA_Checkin_Page_Manager {
+    public static function init() {
+        add_filter( 'theme_page_templates', [ __CLASS__, 'register_template' ] );
+        add_filter( 'template_include', [ __CLASS__, 'load_template' ] );
+    }
+
+    public static function register_template( $templates ) {
+        $templates['host-checkin-template.php'] = __( 'Host Check-In', 'tta' );
+        return $templates;
+    }
+
+    public static function load_template( $template ) {
+        if ( is_page() ) {
+            global $post;
+            $tpl = get_post_meta( $post->ID, '_wp_page_template', true );
+            if ( 'host-checkin-template.php' === $tpl ) {
+                $file = plugin_dir_path( __FILE__ ) . 'templates/host-checkin-template.php';
+                if ( file_exists( $file ) ) {
+                    return $file;
+                }
+            }
+        }
+        return $template;
+    }
+}
+
+TTA_Checkin_Page_Manager::init();

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -873,19 +873,19 @@ if ( $ticket_count > 1 ) {
               <?php else : ?>
                 <li>
                   <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/profile.svg' ); ?>" alt="<?php esc_attr_e( 'Profile', 'tta' ); ?>">
-                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-profile' ) ); ?>" class="tta-dashboard-link" data-tab="profile"><?php esc_html_e( 'Your Profile Info', 'tta' ); ?></a></div>
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=profile', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="profile"><?php esc_html_e( 'Your Profile Info', 'tta' ); ?></a></div>
                 </li>
                 <li>
                   <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/upcoming.svg' ); ?>" alt="<?php esc_attr_e( 'Upcoming', 'tta' ); ?>">
-                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-upcoming' ) ); ?>" class="tta-dashboard-link" data-tab="upcoming"><?php esc_html_e( 'Your Upcoming Events', 'tta' ); ?></a></div>
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=upcoming', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="upcoming"><?php esc_html_e( 'Your Upcoming Events', 'tta' ); ?></a></div>
                 </li>
                 <li>
                   <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/past.svg' ); ?>" alt="<?php esc_attr_e( 'Past', 'tta' ); ?>">
-                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-past' ) ); ?>" class="tta-dashboard-link" data-tab="past"><?php esc_html_e( 'Your Past Events', 'tta' ); ?></a></div>
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=past', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="past"><?php esc_html_e( 'Your Past Events', 'tta' ); ?></a></div>
                 </li>
                 <li>
                   <img class="tta-event-details-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/billing.svg' ); ?>" alt="<?php esc_attr_e( 'Billing', 'tta' ); ?>">
-                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard#tab-billing' ) ); ?>" class="tta-dashboard-link" data-tab="billing"><?php esc_html_e( 'Membership Details', 'tta' ); ?></a></div>
+                  <div class="tta-event-details-icon-after"><a href="<?php echo esc_url( home_url( '/member-dashboard/?tab=billing', 'relative' ) ); ?>" class="tta-dashboard-link" data-tab="billing"><?php esc_html_e( 'Membership Details', 'tta' ); ?></a></div>
                 </li>
                 <li>
                   <img class="tta-event-details-icon logout-icon" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/event-page-icons/login.svg' ); ?>" alt="<?php esc_attr_e( 'Log out', 'tta' ); ?>">

--- a/includes/frontend/templates/host-checkin-template.php
+++ b/includes/frontend/templates/host-checkin-template.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Template Name: Host Check-In
+ *
+ * @package TTA
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+$context = tta_get_current_user_context();
+
+if ( ! $context['is_logged_in'] ) {
+    wp_login_form( [ 'redirect' => get_permalink() ] );
+    return;
+}
+
+$member = $context['member'];
+$allowed = [ 'volunteer', 'admin', 'super_admin' ];
+if ( ! $member || ! in_array( $member['member_type'], $allowed, true ) ) {
+    echo '<p>' . esc_html__( 'You do not have permission to view this page.', 'tta' ) . '</p>';
+    return;
+}
+
+global $wpdb;
+$events_table = $wpdb->prefix . 'tta_events';
+$events = $wpdb->get_results( "SELECT * FROM {$events_table} WHERE date >= CURDATE() ORDER BY date ASC", ARRAY_A );
+$today  = current_time( 'Y-m-d' );
+?>
+<div class="tta-checkin-wrap">
+<table class="widefat striped">
+  <thead>
+    <tr>
+      <th><?php esc_html_e( 'Event Image', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Event Name', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Date', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Status', 'tta' ); ?></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php if ( $events ) :
+    foreach ( $events as $e ) :
+        $status = ( $e['date'] > $today ) ? 'Upcoming' : ( $e['date'] === $today ? 'Today' : 'Past' );
+        if ( ! empty( $e['mainimageid'] ) ) {
+            $img = wp_get_attachment_image( intval( $e['mainimageid'] ), [50,50] );
+        } else {
+            $img = '<img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/default-event.png' ) . '" width="50" height="50" alt="">';
+        }
+  ?>
+    <tr class="tta-event-row" data-event-ute-id="<?php echo esc_attr( $e['ute_id'] ); ?>">
+      <td><?php echo $img; ?></td>
+      <td><?php echo esc_html( $e['name'] ); ?></td>
+      <td><?php echo esc_html( date_i18n( 'n-j-Y', strtotime( $e['date'] ) ) ); ?></td>
+      <td><?php echo esc_html( $status ); ?></td>
+      <td class="tta-toggle-cell"><img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/arrow.svg' ); ?>" class="tta-toggle-arrow" width="16" height="16" alt="Toggle"></td>
+    </tr>
+  <?php endforeach; else : ?>
+    <tr><td colspan="5"><?php esc_html_e( 'No upcoming events found.', 'tta' ); ?></td></tr>
+  <?php endif; ?>
+  </tbody>
+</table>
+</div>
+<?php

--- a/includes/frontend/views/attendance-list.php
+++ b/includes/frontend/views/attendance-list.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+/** @var array $event Event row */
+/** @var array[] $attendees List of attendees */
+?>
+<div class="tta-attendance-details">
+  <h4><?php echo esc_html( $event['name'] ); ?></h4>
+  <p><?php echo esc_html( date_i18n( 'F j, Y', strtotime( $event['date'] ) ) ); ?>
+     <?php echo esc_html( $event['time'] ); ?></p>
+  <p><?php echo esc_html( tta_format_address( $event['address'] ) ); ?></p>
+</div>
+<table class="widefat striped tta-attendance-table">
+  <thead>
+    <tr>
+      <th><?php esc_html_e( 'Attendee', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Email', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Status', 'tta' ); ?></th>
+      <th><?php esc_html_e( 'Actions', 'tta' ); ?></th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php if ( $attendees ) :
+    foreach ( $attendees as $a ) : ?>
+    <tr data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>">
+      <td><?php echo esc_html( $a['first_name'] . ' ' . $a['last_name'] ); ?></td>
+      <td><?php echo esc_html( $a['email'] ); ?></td>
+      <td class="status-label"><?php echo esc_html( ucwords( str_replace('_',' ', $a['status'] ) ) ); ?></td>
+      <td>
+        <button class="button tta-mark-attendance" data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>" data-status="checked_in"><?php esc_html_e( 'Check In', 'tta' ); ?></button>
+        <button class="button tta-mark-attendance" data-attendee-id="<?php echo esc_attr( $a['id'] ); ?>" data-status="no_show"><?php esc_html_e( 'No-Show', 'tta' ); ?></button>
+      </td>
+    </tr>
+  <?php endforeach; else : ?>
+    <tr><td colspan="4"><?php esc_html_e( 'No attendees found.', 'tta' ); ?></td></tr>
+  <?php endif; ?>
+  </tbody>
+</table>

--- a/includes/frontend/views/tab-past-events.php
+++ b/includes/frontend/views/tab-past-events.php
@@ -2,6 +2,46 @@
 <div id="tab-past" class="tta-dashboard-section">
   <h3><?php esc_html_e( 'Your Past Events', 'tta' ); ?></h3>
   <?php
-  // TODO: loop through & render past events
-  ?>
+  $events = tta_get_member_past_events( get_current_user_id() );
+  if ( $events ) :
+      foreach ( $events as $ev ) :
+          $thumb = '';
+          if ( ! empty( $ev['image_id'] ) ) {
+              $thumb = wp_get_attachment_image( $ev['image_id'], 'medium' );
+          } elseif ( ! empty( $ev['page_id'] ) ) {
+              $thumb = get_the_post_thumbnail( $ev['page_id'], 'medium' );
+          }
+
+          $date_str = date_i18n( get_option( 'date_format' ), strtotime( $ev['date'] ) );
+          $time_str = '';
+          if ( ! empty( $ev['time'] ) ) {
+              list( $start, $end ) = explode( '|', $ev['time'] );
+              $time_str = date_i18n( get_option( 'time_format' ), strtotime( $start ) ) . ' – ' . date_i18n( get_option( 'time_format' ), strtotime( $end ) );
+          }
+          ?>
+          <div class="tta-upcoming-event">
+            <?php if ( $thumb ) : ?>
+              <div class="tta-upcoming-thumb"><?php echo $thumb; ?></div>
+            <?php endif; ?>
+            <div class="tta-upcoming-info">
+              <h4><a href="<?php echo esc_url( get_permalink( $ev['page_id'] ) ); ?>"><?php echo esc_html( $ev['name'] ); ?></a></h4>
+              <p class="tta-upcoming-date"><?php echo esc_html( $date_str . ( $time_str ? ' – ' . $time_str : '' ) ); ?></p>
+              <p class="tta-upcoming-address"><?php echo esc_html( tta_format_address( $ev['address'] ) ); ?></p>
+              <p class="tta-upcoming-total"><?php printf( esc_html__( 'Total Paid: $%s', 'tta' ), number_format( $ev['amount'], 2 ) ); ?></p>
+            </div>
+          </div>
+          <?php foreach ( $ev['items'] as $it ) : ?>
+            <div class="tta-ticket-details">
+              <strong><?php echo esc_html( $it['ticket_name'] ); ?> (<?php echo intval( $it['quantity'] ); ?>)</strong>
+              <ul class="tta-attendees">
+              <?php foreach ( (array) ( $it['attendees'] ?? [] ) as $att ) : ?>
+                <li><?php echo esc_html( trim( $att['first_name'] . ' ' . $att['last_name'] ) . ' (' . $att['email'] . ')' ); ?></li>
+              <?php endforeach; ?>
+              </ul>
+            </div>
+          <?php endforeach; ?>
+      <?php endforeach; ?>
+  <?php else : ?>
+      <p><?php esc_html_e( 'No past events found.', 'tta' ); ?></p>
+  <?php endif; ?>
 </div>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -255,6 +255,75 @@ function tta_get_event_attendees( $event_ute_id ) {
 }
 
 /**
+ * Retrieve attendee records with check-in status for a given event.
+ *
+ * @param string $event_ute_id Event ute_id.
+ * @return array[] Array of attendees with status.
+ */
+function tta_get_event_attendees_with_status( $event_ute_id ) {
+    global $wpdb;
+    $att_table     = $wpdb->prefix . 'tta_attendees';
+    $tickets_table = $wpdb->prefix . 'tta_tickets';
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT a.id, a.first_name, a.last_name, a.email, a.phone, a.status
+               FROM {$att_table} a
+               JOIN {$tickets_table} t ON a.ticket_id = t.id
+              WHERE t.event_ute_id = %s
+              ORDER BY a.last_name, a.first_name",
+            $event_ute_id
+        ),
+        ARRAY_A
+    );
+    foreach ( $rows as &$r ) {
+        $r['id']         = intval( $r['id'] );
+        $r['first_name'] = sanitize_text_field( $r['first_name'] );
+        $r['last_name']  = sanitize_text_field( $r['last_name'] );
+        $r['email']      = sanitize_email( $r['email'] );
+        $r['phone']      = sanitize_text_field( $r['phone'] );
+        $r['status']     = sanitize_text_field( $r['status'] );
+    }
+    return $rows;
+}
+
+/**
+ * Update an attendee's status.
+ *
+ * @param int    $attendee_id Attendee ID.
+ * @param string $status      New status.
+ */
+function tta_set_attendance_status( $attendee_id, $status ) {
+    global $wpdb;
+    $att_table = $wpdb->prefix . 'tta_attendees';
+    $status = in_array( $status, [ 'checked_in', 'no_show', 'pending' ], true ) ? $status : 'pending';
+    $wpdb->update( $att_table, [ 'status' => $status ], [ 'id' => intval( $attendee_id ) ], [ '%s' ], [ '%d' ] );
+    TTA_Cache::delete( 'attendance_status_' . intval( $attendee_id ) );
+}
+
+/**
+ * Get an attendee's current check-in status.
+ *
+ * @param int $attendee_id Attendee ID.
+ * @return string Status string.
+ */
+function tta_get_attendance_status( $attendee_id ) {
+    $attendee_id = intval( $attendee_id );
+    $cache_key   = 'attendance_status_' . $attendee_id;
+    $cached      = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+    global $wpdb;
+    $att_table = $wpdb->prefix . 'tta_attendees';
+    $status = $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$att_table} WHERE id = %d", $attendee_id ) );
+    if ( ! $status ) {
+        $status = 'pending';
+    }
+    TTA_Cache::set( $cache_key, $status, 300 );
+    return $status;
+}
+
+/**
  * Retrieve profile image IDs for attendees of a given event.
  *
  * @param int $event_id Event ID.
@@ -452,6 +521,81 @@ function tta_get_member_upcoming_events( $wp_user_id ) {
 }
 
 /**
+ * Retrieve past events purchased by a user.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return array[] List of events with transaction details.
+ */
+function tta_get_member_past_events( $wp_user_id ) {
+    $wp_user_id = intval( $wp_user_id );
+    if ( ! $wp_user_id ) {
+        return [];
+    }
+
+    $cache_key = 'past_events_' . $wp_user_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+    $hist_table    = $wpdb->prefix . 'tta_memberhistory';
+
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT mh.action_data, mh.event_id,
+                    COALESCE(e.name, a.name) AS name,
+                    COALESCE(e.page_id, a.page_id) AS page_id,
+                    COALESCE(e.mainimageid, a.mainimageid) AS mainimageid,
+                    COALESCE(e.date, a.date) AS date,
+                    COALESCE(e.time, a.time) AS time,
+                    COALESCE(e.address, a.address) AS address,
+                    COALESCE(e.type, a.type) AS type,
+                    COALESCE(e.refundsavailable, a.refundsavailable) AS refunds
+               FROM {$hist_table} mh
+               LEFT JOIN {$events_table} e ON mh.event_id = e.id
+               LEFT JOIN {$archive_table} a ON mh.event_id = a.id
+              WHERE mh.wpuserid = %d
+                AND mh.action_type = 'purchase'
+                AND COALESCE(e.date, a.date) < %s
+              ORDER BY COALESCE(e.date, a.date) DESC",
+            $wp_user_id,
+            current_time( 'Y-m-d' )
+        ),
+        ARRAY_A
+    );
+
+    $events = [];
+    foreach ( $rows as $row ) {
+        $data = json_decode( $row['action_data'], true );
+        if ( ! is_array( $data ) ) {
+            continue;
+        }
+        $events[] = [
+            'event_id'       => intval( $row['event_id'] ),
+            'name'           => sanitize_text_field( $row['name'] ),
+            'page_id'        => intval( $row['page_id'] ),
+            'image_id'       => intval( $row['mainimageid'] ),
+            'date'           => $row['date'],
+            'time'           => $row['time'],
+            'address'        => sanitize_text_field( $row['address'] ),
+            'event_type'     => sanitize_text_field( $row['type'] ),
+            'refunds'        => intval( $row['refunds'] ),
+            'transaction_id' => $data['transaction_id'] ?? '',
+            'amount'         => floatval( $data['amount'] ?? 0 ),
+            'items'          => $data['items'] ?? [],
+        ];
+    }
+
+    $ttl = empty( $events ) ? 60 : 300;
+    TTA_Cache::set( $cache_key, $events, $ttl );
+
+    return $events;
+}
+
+/**
  * Retrieve the next upcoming event.
  *
  * @return array|null {
@@ -503,6 +647,58 @@ function tta_get_next_event() {
 
     TTA_Cache::set( $cache_key, $event, 300 );
     return $event;
+}
+
+/**
+ * Retrieve a sample member record for previews.
+ *
+ * @return array{
+ *     first_name:string,
+ *     last_name:string,
+ *     email:string,
+ *     phone:string,
+ *     membership_level:string,
+ *     member_type:string
+ * }
+ */
+function tta_get_sample_member() {
+    $cache_key = 'tta_sample_member';
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $members_table = $wpdb->prefix . 'tta_members';
+    $row = $wpdb->get_row(
+        "SELECT first_name, last_name, email, phone, membership_level, member_type FROM {$members_table} ORDER BY id ASC LIMIT 1",
+        ARRAY_A
+    );
+
+    if ( ! $row ) {
+        $row = [
+            'first_name'       => 'First',
+            'last_name'        => 'Last',
+            'email'            => 'member@example.com',
+            'phone'            => '555-555-5555',
+            'membership_level' => 'basic',
+            'member_type'      => 'member',
+        ];
+        TTA_Cache::set( $cache_key, $row, 60 );
+        return $row;
+    }
+
+    $member = [
+        'first_name'       => sanitize_text_field( $row['first_name'] ?? '' ),
+        'last_name'        => sanitize_text_field( $row['last_name'] ?? '' ),
+        'email'            => sanitize_email( $row['email'] ?? '' ),
+        'phone'            => sanitize_text_field( $row['phone'] ?? '' ),
+        'membership_level' => sanitize_text_field( $row['membership_level'] ?? 'basic' ),
+        'member_type'      => sanitize_text_field( $row['member_type'] ?? 'member' ),
+    ];
+
+    TTA_Cache::set( $cache_key, $member, 300 );
+    return $member;
 }
 
 /**

--- a/tests/EventArchiverTest.php
+++ b/tests/EventArchiverTest.php
@@ -1,0 +1,24 @@
+<?php
+use PHPUnit\Framework\TestCase;
+if (!defined('ABSPATH')) { define('ABSPATH', sys_get_temp_dir().'/wp/'); }
+
+class EventArchiverTest extends TestCase {
+    protected function setUp(): void {
+        if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled($h){ return false; } }
+        if (!function_exists('wp_schedule_event')) { function wp_schedule_event($t,$rec,$hook){ $GLOBALS['scheduled'][] = [$t,$rec,$hook]; } }
+        if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook($hook){ $GLOBALS['cleared'][] = $hook; } }
+        require_once __DIR__ . '/../includes/classes/class-tta-event-archiver.php';
+    }
+
+    protected function tearDown(): void {
+        $GLOBALS['scheduled'] = [];
+        $GLOBALS['cleared'] = [];
+    }
+
+    public function test_schedule_and_clear_events() {
+        TTA_Event_Archiver::schedule_event();
+        $this->assertNotEmpty($GLOBALS['scheduled']);
+        TTA_Event_Archiver::clear_event();
+        $this->assertContains('tta_event_archive_event', $GLOBALS['cleared']);
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -190,6 +190,32 @@ class HelpersTest extends TestCase {
         $this->assertStringContainsString('wp_tta_memberhistory', $wpdb->last_query);
     }
 
+    public function test_get_member_past_events_queries_archive() {
+        global $wpdb;
+        $wpdb->results_data = [
+            [
+                'action_data' => json_encode([
+                    'transaction_id' => 'TX2',
+                    'amount' => 10,
+                    'items' => [ [ 'ticket_name'=>'General', 'quantity'=>1, 'attendees'=>[] ] ]
+                ]),
+                'event_id'    => 5,
+                'name'        => 'Past Event',
+                'page_id'     => 1,
+                'mainimageid' => 2,
+                'date'        => '2020-01-01',
+                'time'        => '10:00|12:00',
+                'address'     => '1 St -  - Town - ST - 00000',
+                'type'        => 'paid',
+                'refunds'     => '0'
+            ]
+        ];
+        $events = tta_get_member_past_events(1);
+        $this->assertCount(1, $events);
+        $this->assertSame('Past Event', $events[0]['name']);
+        $this->assertStringContainsString('wp_tta_events_archive', $wpdb->last_query);
+    }
+
     public function test_get_next_event_returns_cached_row() {
         global $wpdb;
         $this->wpdb->event_row_data = [
@@ -205,5 +231,34 @@ class HelpersTest extends TestCase {
         $ev2 = tta_get_next_event();
         $this->assertSame($ev1, $ev2);
         $this->assertSame('Soon Event', $ev1['name']);
+    }
+
+    public function test_set_attendance_status_updates_db() {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $updated = [];
+            public function update($table, $data, $where, $formats, $where_f) {
+                $this->updated = [$table, $data, $where];
+            }
+        };
+        require_once __DIR__ . '/../includes/helpers.php';
+        tta_set_attendance_status(5, 'checked_in');
+        $this->assertSame('wp_tta_attendees', $wpdb->updated[0]);
+        $this->assertSame('checked_in', $wpdb->updated[1]['status']);
+    }
+
+    public function test_get_event_attendees_with_status_queries_table() {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public $last_query = '';
+            public function get_results($q,$o=ARRAY_A){ $this->last_query = $q; return [ ['id'=>1,'first_name'=>'A','last_name'=>'B','email'=>'e','phone'=>'p','status'=>'pending'] ]; }
+            public function prepare($q,...$a){ foreach($a as $v){ $q=preg_replace('/%s/',$v,$q,1); $q=preg_replace('/%d/',$v,$q,1); } return $q; }
+        };
+        require_once __DIR__ . '/../includes/helpers.php';
+        $rows = tta_get_event_attendees_with_status('ev1');
+        $this->assertCount(1, $rows);
+        $this->assertStringContainsString('wp_tta_attendees', $wpdb->last_query);
     }
 }

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'TTA_PLUGIN_VERSION', '0.2.0' );
-define( 'TTA_DB_VERSION', '1.1.0' );
+define( 'TTA_DB_VERSION', '1.2.0' );
 
 require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-debug-logger.php';
 TTA_Debug_Logger::init();
@@ -102,16 +102,20 @@ require_once TTA_PLUGIN_DIR . 'includes/admin/class-comms-admin.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';
+require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-checkin-page-manager.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart-cleanup.php';
+require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-event-archiver.php';
 
 
 
 // Activation & Deactivation
 register_activation_hook( __FILE__, array( 'TTA_DB_Setup', 'install' ) );
 register_activation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'schedule_event' ) );
+register_activation_hook( __FILE__, array( 'TTA_Event_Archiver', 'schedule_event' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_DB_Setup', 'uninstall' ) );
 register_deactivation_hook( __FILE__, array( 'TTA_Cart_Cleanup', 'clear_event' ) );
+register_deactivation_hook( __FILE__, array( 'TTA_Event_Archiver', 'clear_event' ) );
 
 // Initialize plugin
 add_action( 'plugins_loaded', array( 'TTA_Plugin', 'init' ) );
@@ -144,6 +148,7 @@ class TTA_Plugin {
 
         // Expired cart cleanup
         TTA_Cart_Cleanup::init();
+        TTA_Event_Archiver::init();
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- archive deleted and old events in new `tta_events_archive` table
- cron job moves events older than three days each day
- dashboard past events tab now queries archive as well
- add tests for archiver cron and past events helper
- document archiving in README, Member Dashboard guide, and SQL docs
- add host check-in template and attendance tracking

## Testing
- `composer install`
- `php vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685820a6a9c88320b1df3b00f13cc98c