### PR TITLE
Add Member History admin tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Member Privacy Options](docs/MemberPrivacy.md)
 - [Membership Benefits](docs/MembershipBenefits.md)
 - [Member Dashboard](docs/MemberDashboard.md)
+- [Member History Admin](docs/MemberHistoryAdmin.md)
+- [Become a Member Page](docs/BecomeMemberPage.md)
 - [Email and SMS Templates](docs/EmailSMS.md) – manage message text with live previews and token insertion
 - [Debugging Tools](docs/Debugging.md)
 - [Database Upgrades](docs/DevelopmentSQL.md#automatic-upgrades)

--- a/assets/css/frontend/style.css
+++ b/assets/css/frontend/style.css
@@ -1,3 +1,47 @@
 /* assets/css/frontend/style.css */
 
 /* frontend shortcode styling goes here */
+
+/* arrow toggle for host check-in */
+.tta-toggle-arrow {
+  transition: transform 0.3s ease;
+}
+
+.tta-toggle-arrow.open {
+  transform: rotate(180deg);
+}
+
+/* Become a Member page */
+.tta-become-member-wrap {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.tta-membership-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+}
+.tta-membership-table th,
+.tta-membership-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: center;
+}
+.tta-membership-table td.check {
+  color: green;
+  font-weight: bold;
+}
+.tta-membership-buttons {
+  margin-top: 20px;
+}
+.tta-membership-buttons .button {
+  display: inline-block;
+  margin-right: 15px;
+  padding: 10px 20px;
+  background: #0073aa;
+  color: #fff;
+  text-decoration: none;
+}
+.tta-membership-buttons .button:hover {
+  background: #005177;
+}

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -259,6 +259,34 @@ jQuery(function($){
     $(this).closest('tr').trigger('click');
   });
 
+  // Expand member row to show history details
+  $(document).on('click', '#tta-members-history .widefat tbody tr[data-member-id]', function(e){
+    if ($(e.target).is('a, button, input, textarea, select')) return;
+
+    var $row   = $(this),
+        $arrow = $row.find('.tta-toggle-arrow'),
+        id     = $row.data('member-id'),
+        colsp  = $row.find('td').length,
+        $ex    = $row.next('.tta-inline-row');
+
+    if ($ex.length){
+      $arrow.removeClass('open');
+      $ex.remove();
+      return;
+    }
+
+    $('.tta-inline-row').remove();
+    $('.tta-toggle-arrow').removeClass('open');
+    $arrow.addClass('open');
+
+    $.post(TTA_Ajax.ajax_url, { action:'tta_get_member_history', member_id:id, get_member_nonce:TTA_Ajax.get_member_nonce }, function(res){
+      if(!res.success) return;
+      var $new = $('<tr class="tta-inline-row"><td colspan="'+colsp+'"><div class="tta-inline-container"></div></td></tr>');
+      $row.after($new);
+      $new.find('.tta-inline-container').html(res.data.html).slideDown(200);
+    }, 'json');
+  });
+
   //
   // Update Existing Event (delegate to injected form)
   //
@@ -351,7 +379,7 @@ jQuery(function($){
   // ─────────────────────────────────────────────────────────────────────
   // Inline Edit for “Manage Members” rows
   //
-  $(document).on('click', '.widefat tbody tr[data-member-id]', function(e){
+  $(document).on('click', '#tta-members-manage .widefat tbody tr[data-member-id]', function(e){
     // Don’t trigger if clicking inside controls
     if ( $(e.target).is('a, button, input, textarea, select') ) {
       return;
@@ -982,7 +1010,19 @@ jQuery(function($){
         '{attendee_first_name}': mem.first_name || 'First',
         '{attendee_last_name}': mem.last_name || 'Last',
         '{attendee_email}': mem.email || 'attendee@example.com',
-        '{attendee_phone}': mem.phone || '555-555-5555'
+        '{attendee_phone}': mem.phone || '555-555-5555',
+        '{attendee2_first_name}': mem.first_name || 'First',
+        '{attendee2_last_name}': mem.last_name || 'Last',
+        '{attendee2_email}': mem.email || 'attendee2@example.com',
+        '{attendee2_phone}': mem.phone || '555-555-5556',
+        '{attendee3_first_name}': mem.first_name || 'First',
+        '{attendee3_last_name}': mem.last_name || 'Last',
+        '{attendee3_email}': mem.email || 'attendee3@example.com',
+        '{attendee3_phone}': mem.phone || '555-555-5557',
+        '{attendee4_first_name}': mem.first_name || 'First',
+        '{attendee4_last_name}': mem.last_name || 'Last',
+        '{attendee4_email}': mem.email || 'attendee4@example.com',
+        '{attendee4_phone}': mem.phone || '555-555-5558'
       };
     Object.keys(map).forEach(function(tok){
       var val = map[tok];

--- a/assets/js/frontend/event-checkin.js
+++ b/assets/js/frontend/event-checkin.js
@@ -1,19 +1,27 @@
 jQuery(function($){
   // Toggle event rows
   $(document).on('click', '.tta-event-row', function(e){
-    if ($(e.target).is('button, a, img')) return;
-    var $row = $(this), ute = $row.data('event-ute-id'),
-        $ex = $row.next('.tta-inline-row');
+    if ($(e.target).is('button, a')) return;
+    var $row   = $(this),
+        $arrow = $row.find('.tta-toggle-arrow'),
+        ute    = $row.data('event-ute-id'),
+        $ex    = $row.next('.tta-inline-row');
+
     if ($ex.length){
+      $arrow.removeClass('open');
       $ex.remove();
       return;
     }
+
     $('.tta-inline-row').remove();
+    $('.tta-toggle-arrow').removeClass('open');
+
     $.post(TTA_Checkin.ajax_url, { action:'tta_get_event_attendance', nonce:TTA_Checkin.get_nonce, event_ute_id: ute }, function(res){
       if(!res.success) return;
       var colspan = $row.find('td').length;
       var $new = $('<tr class="tta-inline-row"><td colspan="'+colspan+'">'+res.data.html+'</td></tr>');
       $row.after($new);
+      $arrow.addClass('open');
     }, 'json');
   });
 

--- a/docs/BecomeMemberPage.md
+++ b/docs/BecomeMemberPage.md
@@ -1,0 +1,17 @@
+# Become a Member Page
+
+The **Become a Member** template introduces a front‑end landing page for membership information. Assign the template to a WordPress page whose URL ends in `/become-a-member/`.
+
+## Overview
+- Located at `includes/frontend/templates/become-member-page-template.php`.
+- Registered by `TTA_Become_Member_Page`.
+- Describes Basic vs. Premium benefits in a simple table.
+- Includes buttons that link to WooCommerce products to add the membership to the cart.
+
+## Sign Up Links
+The sign up buttons direct visitors to the following URLs which automatically add the product to the WooCommerce cart:
+
+- Basic Membership: `/product/membership/?add-to-cart=7184`
+- Premium Membership: `/product/premium-membership/?add-to-cart=378`
+
+Adjust the product IDs if they differ on your installation.

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -83,6 +83,18 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 {attendee_last_name}
 {attendee_email}
 {attendee_phone}
+{attendee2_first_name}
+{attendee2_last_name}
+{attendee2_email}
+{attendee2_phone}
+{attendee3_first_name}
+{attendee3_last_name}
+{attendee3_email}
+{attendee3_phone}
+{attendee4_first_name}
+{attendee4_last_name}
+{attendee4_email}
+{attendee4_phone}
 ```
 
 Use the **Line Break** button to insert a newline. Email previews render these breaks as HTML `<br>` tags so the saved text remains plain.

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -1,0 +1,12 @@
+# Member History Admin Tab
+
+The **Member History** tab is available under **Members** in the WordPress admin. It lists all members just like the Manage Members tab. Clicking a member row loads a detailed history view showing:
+
+- Total amount spent across all transactions
+- Count of events they have purchased
+- Count of events checked in
+- Count of no‑shows
+- Number of refund or cancellation requests
+- A table of all past event transactions
+
+Data is pulled from `tta_memberhistory`, `tta_transactions`, `tta_attendees`, `tta_events`, and `tta_events_archive`.

--- a/includes/admin/class-comms-admin.php
+++ b/includes/admin/class-comms-admin.php
@@ -201,7 +201,19 @@ class TTA_Comms_Admin {
             echo '<button type="button" class="button tta-insert-token" data-token="{attendee_first_name}">{attendee_first_name}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{attendee_last_name}">{attendee_last_name}</button> ';
             echo '<button type="button" class="button tta-insert-token" data-token="{attendee_email}">{attendee_email}</button> ';
-            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_phone}">{attendee_phone}</button></div>';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee_phone}">{attendee_phone}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee2_first_name}">{attendee2_first_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee2_last_name}">{attendee2_last_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee2_email}">{attendee2_email}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee2_phone}">{attendee2_phone}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee3_first_name}">{attendee3_first_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee3_last_name}">{attendee3_last_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee3_email}">{attendee3_email}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee3_phone}">{attendee3_phone}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_first_name}">{attendee4_first_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_last_name}">{attendee4_last_name}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_email}">{attendee4_email}</button> ';
+            echo '<button type="button" class="button tta-insert-token" data-token="{attendee4_phone}">{attendee4_phone}</button></div>';
 
             echo '<button type="button" class="button tta-insert-br">Line Break</button>';
             echo '</td></tr>';

--- a/includes/admin/class-members-admin.php
+++ b/includes/admin/class-members-admin.php
@@ -27,9 +27,8 @@ class TTA_Members_Admin {
 
     public function render_list() {
         // Determine which “tab” is active: create vs. manage
-        $tab = isset( $_GET['tab'] ) && $_GET['tab'] === 'create'
-             ? 'create'
-             : 'manage';
+        $allowed = [ 'create', 'manage', 'history' ];
+        $tab = isset( $_GET['tab'] ) && in_array( $_GET['tab'], $allowed, true ) ? $_GET['tab'] : 'manage';
 
         // Render horizontal tabs, matching the style of Events
         echo '<div class="wrap">';
@@ -49,11 +48,18 @@ class TTA_Members_Admin {
                 esc_url( admin_url( 'admin.php?page=tta-members&tab=manage' ) ),
                 $tab === 'manage' ? 'nav-tab-active' : ''
             );
+            printf(
+                '<a href="%1$s" class="nav-tab %2$s">Member History</a>',
+                esc_url( admin_url( 'admin.php?page=tta-members&tab=history' ) ),
+                $tab === 'history' ? 'nav-tab-active' : ''
+            );
           echo '</h2>';
 
           // Load the appropriate view
           if ( $tab === 'create' ) {
               include plugin_dir_path( __FILE__ ) . '../admin/views/members-create.php';
+          } elseif ( $tab === 'history' ) {
+              include plugin_dir_path( __FILE__ ) . '../admin/views/members-history.php';
           } else {
               include plugin_dir_path( __FILE__ ) . '../admin/views/members-manage.php';
           }

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -1,0 +1,41 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+$member_id = intval( $_GET['member_id'] ?? 0 );
+if ( ! $member_id ) { echo '<p>Missing member.</p>'; return; }
+
+global $wpdb;
+$members_table = $wpdb->prefix . 'tta_members';
+$member = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$members_table} WHERE id=%d", $member_id ), ARRAY_A );
+if ( ! $member ) { echo '<p>Member not found.</p>'; return; }
+
+$summary = tta_get_member_history_summary( $member_id );
+?>
+<div class="tta-member-history-details">
+  <h3><?php echo esc_html( $member['first_name'] . ' ' . $member['last_name'] ); ?></h3>
+  <p><?php echo esc_html( $member['email'] ); ?></p>
+  <h4><?php esc_html_e( 'Member Summary', 'tta' ); ?></h4>
+  <ul>
+    <li><?php printf( esc_html__( 'Total Spent: $%s', 'tta' ), number_format( $summary['total_spent'], 2 ) ); ?></li>
+    <li><?php printf( esc_html__( 'Events Attended: %d', 'tta' ), $summary['attended'] ); ?></li>
+    <li><?php printf( esc_html__( 'No-Shows: %d', 'tta' ), $summary['no_show'] ); ?></li>
+    <li><?php printf( esc_html__( 'Refund/Cancellation Requests: %d', 'tta' ), $summary['refunds'] + $summary['cancellations'] ); ?></li>
+    <li><?php printf( esc_html__( 'Total Events Purchased: %d', 'tta' ), $summary['events'] ); ?></li>
+  </ul>
+  <h4><?php esc_html_e( 'Event History', 'tta' ); ?></h4>
+  <table class="widefat striped">
+    <thead>
+      <tr><th><?php esc_html_e( 'Event', 'tta' ); ?></th><th><?php esc_html_e( 'Date', 'tta' ); ?></th><th><?php esc_html_e( 'Amount', 'tta' ); ?></th></tr>
+    </thead>
+    <tbody>
+      <?php if ( $summary['transactions'] ) : foreach ( $summary['transactions'] as $tx ) : ?>
+      <tr>
+        <td><?php echo esc_html( $tx['name'] ); ?></td>
+        <td><?php echo esc_html( date_i18n( 'F j, Y', strtotime( $tx['date'] ) ) ); ?></td>
+        <td>$<?php echo esc_html( number_format( $tx['amount'], 2 ) ); ?></td>
+      </tr>
+      <?php endforeach; else : ?>
+      <tr><td colspan="3"><?php esc_html_e( 'No transactions found.', 'tta' ); ?></td></tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
+</div>

--- a/includes/admin/views/members-history.php
+++ b/includes/admin/views/members-history.php
@@ -1,0 +1,159 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * We will query the `tta_members` table to get the first page (10 per page),
+ * along with any search filter (by first_name, last_name, or email).
+ *
+ * Then we output a `<table class="widefat">` with a toggle arrow column
+ * (just like Manage Events), then columns: First Name, Last Name, Email, Member Type, Joined At, Actions.
+ *
+ * Each row has: data‐member‐id="{ID from tta_members}" so that our JS can hook into it.
+ */
+
+// Basic pagination and search parameters:
+global $wpdb;
+$members_table = $wpdb->prefix . 'tta_members';
+
+$per_page = 10;
+$page      = isset( $_GET['paged'] ) ? max( 1, intval( $_GET['paged'] ) ) : 1;
+$offset    = ( $page - 1 ) * $per_page;
+
+// Build the WHERE clause for searching:
+$where_sql   = '';
+$search_term = isset( $_GET['s'] ) ? tta_sanitize_text_field( $_GET['s'] ) : '';
+if ( $search_term ) {
+    $like = '%' . $wpdb->esc_like( $search_term ) . '%';
+    $where_sql = $wpdb->prepare(
+        "WHERE first_name LIKE %s OR last_name LIKE %s OR email LIKE %s",
+        $like,
+        $like,
+        $like
+    );
+}
+
+// Fetch total count (for pagination)
+$total_members = $wpdb->get_var( "SELECT COUNT(*) FROM {$members_table} {$where_sql}" );
+
+// Fetch this page’s rows
+$members = $wpdb->get_results( $wpdb->prepare(
+    "SELECT * FROM {$members_table} {$where_sql} ORDER BY joined_at DESC LIMIT %d OFFSET %d",
+    $per_page,
+    $offset
+), ARRAY_A );
+
+$total_pages = ceil( $total_members / $per_page );
+
+?>
+
+<div id="tta-members-history">
+
+    <!-- Search Form (already present above in class‐members‐admin) -->
+    <!-- The form resides in class‐members‐admin; this file focuses on the table -->
+
+    <?php if ( $search_term ): ?>
+        <p class="subtitle">Search results for "<strong><?php echo esc_html( $search_term ); ?></strong>"</p>
+    <?php endif; ?>
+    <form method="get" style="margin-bottom: 20px;">
+      <input type="hidden" name="page" value="tta-members">
+      <input type="hidden" name="tab" value="history">
+      <p class="search-box">
+        <label class="screen-reader-text" for="member-search-input">Search Members:</label>
+        <input
+          type="search"
+          id="member-search-input"
+          name="s"
+          value="<?php echo esc_attr( $_GET['s'] ?? '' ); ?>"
+          placeholder="Search by first name, last name, or email…"
+        >
+        <button class="button" type="submit">Search Members</button>
+      </p>
+    </form>
+
+    <table class="widefat fixed striped">
+        <thead>
+            <tr>
+                <th class="manage-column column-image">Profile Image</th>
+                <th class="manage-column column-firstname">First Name</th>
+                <th class="manage-column column-lastname">Last Name</th>
+                <th class="manage-column column-email">Email</th>
+                <th class="manage-column column-membertype">Type</th>
+                <th class="manage-column column-joined">Joined</th>
+                <th class="manage-column column-actions">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if ( ! empty( $members ) ): ?>
+            <?php foreach ( $members as $member ): ?>
+
+                <?php
+                    $attachment_id = $member['profileimgid']; // e.g. 123 or retrieved dynamically via get_post_thumbnail_id(), etc.
+
+                    // Define your default‐image URL (absolute or relative to your theme/plugin).
+                    $default_image_url = esc_url( TTA_PLUGIN_URL . 'assets/images/admin/placeholder-profile.svg' );;
+
+                    if ( ! empty( $attachment_id ) ) {
+                        // Try to get the “full” size URL (you can swap 'full' for 'thumbnail', 'medium', 'large', etc.).
+                        $image_url = wp_get_attachment_image_url( $attachment_id, 'full' );
+
+                        // If for some reason wp_get_attachment_image_url() returned false, revert to default.
+                        if ( ! $image_url ) {
+                            $image_url = $default_image_url;
+                        }
+                    } else {
+                        // No attachment ID was provided—use default immediately.
+                        $image_url = $default_image_url;
+                    }
+                ?>
+
+                <?php
+                    // convert to a UNIX timestamp
+                    $ts = strtotime( $member['joined_at'] );
+
+                    // human‐readable absolute date
+                    $readable_date = date_i18n( 'F j, Y \a\t g:i A', $ts );
+                    // e.g. “June 12, 2025 at 11:30 AM”
+
+                ?>
+
+                <tr data-member-id="<?php echo esc_attr( $member['id'] ); ?>">
+                    <td class="tta-member-center-profile-img"><?php echo '<img class="tta-member-edit-unexpanded-profile-img" src="' . $image_url . '"/>' ?></td>
+                    <td><?php echo esc_html( $member['first_name'] ); ?></td>
+                    <td><?php echo esc_html( $member['last_name'] ); ?></td>
+                    <td><?php echo esc_html( $member['email'] ); ?></td>
+                    <td><?php echo esc_html( ucfirst( str_replace( '_', ' ', $member['member_type'] ) ) ); ?></td>
+                    <td><?php echo esc_html( $readable_date ); ?></td>
+                    <td>
+                        <a href="#" class="tta-edit-link">View History</a>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <tr>
+                <td colspan="7">No members found.</td>
+            </tr>
+        <?php endif; ?>
+        </tbody>
+    </table>
+
+    <!-- Pagination Links -->
+    <?php if ( $total_pages > 1 ): ?>
+        <div class="tablenav">
+            <div class="tablenav-pages">
+                <?php
+                    echo paginate_links( [
+                        'base'      => add_query_arg( 'paged', '%#%' ),
+                        'format'    => '',
+                        'prev_text' => '&laquo;',
+                        'next_text' => '&raquo;',
+                        'total'     => $total_pages,
+                        'current'   => $page,
+                    ] );
+                ?>
+            </div>
+        </div>
+    <?php endif; ?>
+
+</div>

--- a/includes/ajax/handlers/class-ajax-members.php
+++ b/includes/ajax/handlers/class-ajax-members.php
@@ -11,6 +11,7 @@ class TTA_Ajax_Members {
         add_action( 'wp_ajax_tta_save_member',        [ __CLASS__, 'save_member' ] );
         add_action( 'wp_ajax_tta_get_member',         [ __CLASS__, 'get_member' ] );
         add_action( 'wp_ajax_tta_get_member_form',    [ __CLASS__, 'get_member_form' ] );
+        add_action( 'wp_ajax_tta_get_member_history', [ __CLASS__, 'get_member_history' ] );
         add_action( 'wp_ajax_tta_update_member',      [ __CLASS__, 'update_member' ] );
         add_action( 'wp_ajax_tta_front_update_member',[ __CLASS__, 'update_member_front' ] );
     }
@@ -219,6 +220,18 @@ class TTA_Ajax_Members {
         include TTA_PLUGIN_DIR . 'includes/admin/views/members-edit.php';
         $html = ob_get_clean();
         wp_send_json_success([ 'html'=>$html ]);
+    }
+
+    public static function get_member_history() {
+        check_ajax_referer( 'tta_member_update_action', 'get_member_nonce' );
+        if ( empty( $_POST['member_id'] ) ) {
+            wp_send_json_error( [ 'message' => 'Missing member ID.' ] );
+        }
+        $_GET['member_id'] = intval( $_POST['member_id'] );
+        ob_start();
+        include TTA_PLUGIN_DIR . 'includes/admin/views/member-history-details.php';
+        $html = ob_get_clean();
+        wp_send_json_success( [ 'html' => $html ] );
     }
 
     public static function update_member() {

--- a/includes/frontend/class-become-member-page.php
+++ b/includes/frontend/class-become-member-page.php
@@ -1,0 +1,30 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class TTA_Become_Member_Page {
+    public static function init() {
+        add_filter( 'theme_page_templates', [ __CLASS__, 'register_template' ] );
+        add_filter( 'template_include',      [ __CLASS__, 'load_template' ] );
+    }
+
+    public static function register_template( $templates ) {
+        $templates['become-member-page-template.php'] = __( 'Become a Member', 'tta' );
+        return $templates;
+    }
+
+    public static function load_template( $template ) {
+        if ( is_page() ) {
+            global $post;
+            $tpl = get_post_meta( $post->ID, '_wp_page_template', true );
+            if ( 'become-member-page-template.php' === $tpl ) {
+                $file = plugin_dir_path( __FILE__ ) . 'templates/become-member-page-template.php';
+                if ( file_exists( $file ) ) {
+                    return $file;
+                }
+            }
+        }
+        return $template;
+    }
+}
+
+TTA_Become_Member_Page::init();

--- a/includes/frontend/templates/become-member-page-template.php
+++ b/includes/frontend/templates/become-member-page-template.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Template Name: Become a Member
+ *
+ * Displays membership options and benefits.
+ *
+ * @package TTA
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+get_header();
+?>
+<div class="tta-become-member-wrap">
+  <h1><?php esc_html_e( 'Become a Trying to Adult Member', 'tta' ); ?></h1>
+  <p><?php esc_html_e( 'Join our community and unlock special perks at local events.', 'tta' ); ?></p>
+
+  <table class="tta-membership-table">
+    <thead>
+      <tr>
+        <th><?php esc_html_e( 'Benefits', 'tta' ); ?></th>
+        <th><?php esc_html_e( 'Basic', 'tta' ); ?></th>
+        <th><?php esc_html_e( 'Premium', 'tta' ); ?></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><?php esc_html_e( 'Access to free events every month', 'tta' ); ?></td>
+        <td class="check">&#10003;</td>
+        <td class="check">&#10003;</td>
+      </tr>
+      <tr>
+        <td><?php esc_html_e( 'Early access to new events', 'tta' ); ?></td>
+        <td></td>
+        <td class="check">&#10003;</td>
+      </tr>
+      <tr>
+        <td><?php esc_html_e( 'Discounts on paid events', 'tta' ); ?></td>
+        <td></td>
+        <td class="check">&#10003;</td>
+      </tr>
+      <tr>
+        <td><?php esc_html_e( 'Local discounts (coming soon)', 'tta' ); ?></td>
+        <td></td>
+        <td class="check">&#10003;</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="tta-membership-buttons">
+    <a class="button" href="<?php echo esc_url( home_url( '/product/membership/?add-to-cart=7184' ) ); ?>">
+      <?php esc_html_e( 'Sign Up for Basic', 'tta' ); ?>
+    </a>
+    <a class="button" href="<?php echo esc_url( home_url( '/product/premium-membership/?add-to-cart=378' ) ); ?>">
+      <?php esc_html_e( 'Sign Up for Premium', 'tta' ); ?>
+    </a>
+  </div>
+</div>
+<?php
+get_footer();

--- a/includes/frontend/templates/host-checkin-template.php
+++ b/includes/frontend/templates/host-checkin-template.php
@@ -25,6 +25,8 @@ global $wpdb;
 $events_table = $wpdb->prefix . 'tta_events';
 $events = $wpdb->get_results( "SELECT * FROM {$events_table} WHERE date >= CURDATE() ORDER BY date ASC", ARRAY_A );
 $today  = current_time( 'Y-m-d' );
+
+get_header();
 ?>
 <div class="tta-checkin-wrap">
 <table class="widefat striped">
@@ -61,3 +63,5 @@ $today  = current_time( 'Y-m-d' );
 </table>
 </div>
 <?php
+get_footer();
+

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -596,6 +596,117 @@ function tta_get_member_past_events( $wp_user_id ) {
 }
 
 /**
+ * Summarize a member's purchase and attendance history.
+ *
+ * @param int $member_id Member ID.
+ * @return array Summary data.
+ */
+function tta_get_member_history_summary( $member_id ) {
+    $member_id = intval( $member_id );
+    if ( ! $member_id ) {
+        return [
+            'total_spent'   => 0,
+            'events'        => 0,
+            'attended'      => 0,
+            'no_show'       => 0,
+            'refunds'       => 0,
+            'cancellations' => 0,
+            'transactions'  => [],
+        ];
+    }
+
+    $cache_key = 'member_hist_sum_' . $member_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $hist_table    = $wpdb->prefix . 'tta_memberhistory';
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+    $tx_table      = $wpdb->prefix . 'tta_transactions';
+    $att_table     = $wpdb->prefix . 'tta_attendees';
+
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT mh.action_data, mh.event_id,
+                    COALESCE(e.name, a.name)   AS name,
+                    COALESCE(e.date, a.date)   AS date,
+                    COALESCE(e.time, a.time)   AS time,
+                    COALESCE(e.address, a.address) AS address
+               FROM {$hist_table} mh
+               LEFT JOIN {$events_table} e ON mh.event_id = e.id
+               LEFT JOIN {$archive_table} a ON mh.event_id = a.id
+              WHERE mh.member_id = %d
+                AND mh.action_type = 'purchase'
+              ORDER BY COALESCE(e.date, a.date) DESC",
+            $member_id
+        ),
+        ARRAY_A
+    );
+
+    $summary = [
+        'total_spent'   => 0,
+        'events'        => 0,
+        'attended'      => 0,
+        'no_show'       => 0,
+        'refunds'       => 0,
+        'cancellations' => 0,
+        'transactions'  => [],
+    ];
+
+    $event_ids = [];
+    foreach ( $rows as $row ) {
+        $data   = json_decode( $row['action_data'], true );
+        $amount = floatval( $data['amount'] ?? 0 );
+        $summary['total_spent'] += $amount;
+        $event_ids[] = intval( $row['event_id'] );
+        $summary['transactions'][] = [
+            'event_id'       => intval( $row['event_id'] ),
+            'name'           => sanitize_text_field( $row['name'] ),
+            'date'           => $row['date'],
+            'time'           => $row['time'],
+            'address'        => sanitize_text_field( $row['address'] ),
+            'amount'         => $amount,
+            'transaction_id' => $data['transaction_id'] ?? '',
+        ];
+    }
+
+    $summary['events'] = count( array_unique( $event_ids ) );
+
+    $status_rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT a.status FROM {$att_table} a
+             JOIN {$tx_table} t ON a.transaction_id = t.id
+            WHERE t.member_id = %d",
+            $member_id
+        ),
+        ARRAY_A
+    );
+    foreach ( $status_rows as $r ) {
+        if ( 'checked_in' === $r['status'] ) {
+            $summary['attended']++;
+        } elseif ( 'no_show' === $r['status'] ) {
+            $summary['no_show']++;
+        }
+    }
+
+    $summary['refunds'] = (int) $wpdb->get_var( $wpdb->prepare(
+        "SELECT COUNT(*) FROM {$hist_table} WHERE member_id = %d AND action_type = 'refund_request'",
+        $member_id
+    ) );
+
+    $summary['cancellations'] = (int) $wpdb->get_var( $wpdb->prepare(
+        "SELECT COUNT(*) FROM {$hist_table} WHERE member_id = %d AND action_type = 'cancel_request'",
+        $member_id
+    ) );
+
+    TTA_Cache::set( $cache_key, $summary, 300 );
+    return $summary;
+}
+
+/**
  * Retrieve the next upcoming event.
  *
  * @return array|null {

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -103,6 +103,7 @@ require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-events-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/shortcodes/class-members-shortcode.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-member-dashboard.php';
 require_once TTA_PLUGIN_DIR . 'includes/frontend/class-tta-checkin-page-manager.php';
+require_once TTA_PLUGIN_DIR . 'includes/frontend/class-become-member-page.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart.php';
 require_once TTA_PLUGIN_DIR . 'includes/cart/class-cart-cleanup.php';
 require_once TTA_PLUGIN_DIR . 'includes/classes/class-tta-event-archiver.php';


### PR DESCRIPTION
## Summary
- add a Become a Member front-end page template for membership info
- document the new template and signup links
- link the doc from the README
- register the page template loader
- style the new membership table and buttons

## Testing
- `composer install`
- `php vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_685855c8a50883208a56483e8aa7fcc1