### PR TITLE
Fix event list warnings and icon layout

### DIFF
--- a/assets/css/frontend/event-page.css
+++ b/assets/css/frontend/event-page.css
@@ -97,18 +97,28 @@
 
 /* Main + Sidebar */
 .tta-event-content-wrap {
-  display: flex;
-  flex-wrap: wrap;
   max-width: 1200px;
   margin: 40px auto;
 }
+.tta-event-columns {
+  display: flex;
+  gap: 20px;
+}
+.tta-event-left {
+  flex: 0 0 220px;
+  align-self: flex-start;
+}
+.tta-stick-on-scroll {
+  position: sticky;
+  top: 80px;
+}
 .tta-event-main {
-  flex: 0 0 65%;
+  flex: 1 1 auto;
   padding-right: 30px;
 }
 
 .tta-event-sidebar {
-  flex: 0 0 30%;
+  flex: 0 0 300px;
   background: #fafafa;
   padding: 20px;
   border-radius: 4px;
@@ -556,8 +566,15 @@ input[disabled] {
 
 /* Responsive */
 @media (max-width: 800px) {
-  .tta-event-content-wrap {
+  .tta-event-columns {
     flex-direction: column;
+  }
+  .tta-event-left,
+  .tta-event-sidebar {
+    flex: 1 1 auto;
+  }
+  .tta-event-main {
+    padding-right: 0;
   }
   .tta-event-hero-inner {
     flex-direction: column;

--- a/assets/css/frontend/events-list.css
+++ b/assets/css/frontend/events-list.css
@@ -201,18 +201,18 @@
 }
 .tta-event-detail-list li {
   margin-bottom: 4px;
+  display: flex;
+  align-items: flex-start;
 }
 .tta-event-details-icon {
   width: 18px;
-  display: inline-block;
+  flex: 0 0 auto;
   position: relative;
   top: 2px;
   margin-right: 4px;
 }
 .tta-event-details-icon-after {
-  display: inline-block;
-  width: calc(100% - 22px);
-  vertical-align: top;
+  flex: 1 1 auto;
 }
 
 @media (max-width: 768px) {

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -2,6 +2,10 @@
 
 This document summarizes helper functions and template behavior related to user context on the Event Page.
 
+## Layout Overview
+
+The template now uses a three-column layout, mirroring the Events List Page. A random ad image occupies a narrow left column and stays visible while scrolling. The center column contains the main event content and the familiar sidebar remains on the right.
+
 ## Current User Context Helper
 
 `tta_get_current_user_context()` returns information about the visiting user and any linked member record. The data is cached for five minutes to reduce queries.

--- a/docs/EventsListPage.md
+++ b/docs/EventsListPage.md
@@ -30,3 +30,7 @@ Use the `events-list-page-template.php` page template from the **Page Attributes
 section when creating a WordPress page. Each list item links to the associated
 Event Page. Front‑end styling is provided by `assets/css/frontend/events-list.css`
 which is automatically enqueued when this template is active.
+
+The icon and text pairs within `.tta-event-detail-list` are arranged with flexbox
+to keep them on a single line. Time strings are parsed safely, so missing or
+malformed values no longer trigger PHP warnings.

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -149,6 +149,13 @@ class TTA_Assets {
                 TTA_PLUGIN_VERSION,
                 true
             );
+            wp_enqueue_script(
+                'tta-sticky-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/sticky-scroll.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
 
             wp_enqueue_style(
                 'tta-popup-css',

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -310,14 +310,16 @@ $map_url           = "https://www.google.com/maps/search/?api=1&query={$map_quer
 // 7) Format date & time
 // ───────────────
 $timestamp = strtotime( $event['date'] );
-$date_str  = date_i18n( get_option( 'date_format' ), $timestamp );
-list( $start, $end ) = explode( '|', $event['time'] );
+$date_str = date_i18n( get_option( 'date_format' ), $timestamp );
+$parts    = array_pad( explode( '|', $event['time'] ), 2, '' );
+$start    = $parts[0];
+$end      = $parts[1];
 if ( $event['all_day_event'] ) {
     $time_str = esc_html__( 'All day', 'tta' );
 } else {
-    $time_str = date_i18n( get_option( 'time_format' ), strtotime( $start ) )
-              . ' – '
-              . date_i18n( get_option( 'time_format' ), strtotime( $end ) );
+    $start_fmt = $start ? date_i18n( get_option( 'time_format' ), strtotime( $start ) ) : '';
+    $end_fmt   = $end ? date_i18n( get_option( 'time_format' ), strtotime( $end ) ) : '';
+    $time_str  = trim( $start_fmt . ( $end_fmt ? ' – ' . $end_fmt : '' ) );
 }
 
 // ───────────────
@@ -608,9 +610,23 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
 
   <!-- MAIN + SIDEBAR -->
   <div class="tta-event-content-wrap">
+    <div class="tta-event-columns">
+      <aside class="tta-event-left">
+        <div class="tta-events-ad tta-stick-on-scroll">
+          <?php $ad = tta_get_random_ad(); ?>
+          <?php if ( $ad ) : ?>
+            <?php $img = wp_get_attachment_image( intval( $ad['image_id'] ), 'medium' ); ?>
+            <?php if ( $ad['url'] ) : ?><a href="<?php echo esc_url( $ad['url'] ); ?>"><?php endif; ?>
+            <?php echo $img ? $img : '<img src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ) . '" alt="">'; ?>
+            <?php if ( $ad['url'] ) : ?></a><?php endif; ?>
+          <?php else : ?>
+            <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/ads/placeholder1.svg' ); ?>" alt="Ad" />
+          <?php endif; ?>
+        </div>
+      </aside>
 
-    <!-- MAIN CONTENT -->
-    <main class="tta-event-main">
+      <!-- MAIN CONTENT -->
+      <main class="tta-event-main">
 
       <?php if ( $raw_content ) : ?>
         <section class="tta-event-section tta-event-description-accordion">
@@ -1068,6 +1084,7 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
         </div>
       <?php endif; ?>
     </aside>
+    </div><!-- .tta-event-columns -->
 
   </div><!-- .tta-event-content-wrap -->
 
@@ -1087,8 +1104,9 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
             $default = esc_url( TTA_PLUGIN_URL . 'assets/images/admin/default-event.png' );
             $img     = '<img src="' . $default . '" alt="' . esc_attr( $re['name'] ) . '" class="tta-related-event-img">';
           }
-          list( $rs, ) = explode( '|', $re['time'] );
-          $re_ts = strtotime( $re['date'] . ' ' . $rs );
+          $time_parts = array_pad( explode( '|', $re['time'] ), 2, '' );
+          $rs        = $time_parts[0];
+          $re_ts     = strtotime( $re['date'] . ( $rs ? ' ' . $rs : '' ) );
           $dt_iso = date( 'c', $re_ts );
           $dt_disp = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $re_ts );
         ?>

--- a/includes/frontend/templates/events-list-page-template.php
+++ b/includes/frontend/templates/events-list-page-template.php
@@ -176,10 +176,18 @@ $next_url = $next_allowed ? add_query_arg( [ 'cal_year' => $next_year, 'cal_mont
             $default  = esc_url( TTA_PLUGIN_URL . 'assets/images/admin/default-event.png' );
             $img_html = '<img src="' . $default . '" alt="" class="attachment-medium size-medium" />';
         }
-        $ts        = strtotime( $ev['date'] );
-        $date_str  = date_i18n( 'm-d-Y', $ts );
-        list( $start, $end ) = explode( '|', $ev['time'] );
-        $time_str = $ev['all_day_event'] ? esc_html__( 'All day', 'tta' ) : date_i18n( get_option( 'time_format' ), strtotime( $start ) ) . ' – ' . date_i18n( get_option( 'time_format' ), strtotime( $end ) );
+        $ts       = strtotime( $ev['date'] );
+        $date_str = date_i18n( 'm-d-Y', $ts );
+        $parts    = array_pad( explode( '|', $ev['time'] ), 2, '' );
+        $start    = $parts[0];
+        $end      = $parts[1];
+        if ( $ev['all_day_event'] ) {
+            $time_str = esc_html__( 'All day', 'tta' );
+        } else {
+            $start_fmt = $start ? date_i18n( get_option( 'time_format' ), strtotime( $start ) ) : '';
+            $end_fmt   = $end ? date_i18n( get_option( 'time_format' ), strtotime( $end ) ) : '';
+            $time_str  = trim( $start_fmt . ( $end_fmt ? ' – ' . $end_fmt : '' ) );
+        }
         $address   = tta_format_address( $ev['address'] );
         $content   = get_post_field( 'post_content', $ev['page_id'] );
         $excerpt   = wp_trim_words( wp_strip_all_tags( $content ), 25, '…' );

--- a/includes/frontend/views/tab-past-events.php
+++ b/includes/frontend/views/tab-past-events.php
@@ -15,8 +15,10 @@
           $date_str = date_i18n( get_option( 'date_format' ), strtotime( $ev['date'] ) );
           $time_str = '';
           if ( ! empty( $ev['time'] ) ) {
-              list( $start, $end ) = explode( '|', $ev['time'] );
-              $time_str = date_i18n( get_option( 'time_format' ), strtotime( $start ) ) . ' – ' . date_i18n( get_option( 'time_format' ), strtotime( $end ) );
+              $parts     = array_pad( explode( '|', $ev['time'] ), 2, '' );
+              $start_fmt = $parts[0] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[0] ) ) : '';
+              $end_fmt   = $parts[1] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[1] ) ) : '';
+              $time_str  = trim( $start_fmt . ( $end_fmt ? ' – ' . $end_fmt : '' ) );
           }
           ?>
           <div class="tta-upcoming-event">

--- a/includes/frontend/views/tab-upcoming.php
+++ b/includes/frontend/views/tab-upcoming.php
@@ -15,8 +15,10 @@
           $date_str = date_i18n( get_option( 'date_format' ), strtotime( $ev['date'] ) );
           $time_str = '';
           if ( ! empty( $ev['time'] ) ) {
-              list( $start, $end ) = explode( '|', $ev['time'] );
-              $time_str = date_i18n( get_option( 'time_format' ), strtotime( $start ) ) . ' – ' . date_i18n( get_option( 'time_format' ), strtotime( $end ) );
+              $parts     = array_pad( explode( '|', $ev['time'] ), 2, '' );
+              $start_fmt = $parts[0] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[0] ) ) : '';
+              $end_fmt   = $parts[1] ? date_i18n( get_option( 'time_format' ), strtotime( $parts[1] ) ) : '';
+              $time_str  = trim( $start_fmt . ( $end_fmt ? ' – ' . $end_fmt : '' ) );
           }
           ?>
           <div class="tta-upcoming-event">


### PR DESCRIPTION
## Summary
- avoid warnings when event time is missing
- align event detail icons and text on one line
- note icon layout in docs
- add left ad column to single event page

## Testing
- `php -l includes/frontend/templates/event-page-template.php`
- `php -l includes/frontend/templates/events-list-page-template.php`
- `php -l includes/classes/class-tta-assets.php`
- `php -l includes/frontend/views/tab-upcoming.php`
- `composer install` *(fails: command not found)*
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685ab3f730008320a6553e3d18e7ebf3