### PR TITLE
Display member summary data in table

### DIFF
--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -957,7 +957,7 @@ jQuery(function($){
     e.preventDefault();
     var $btn  = $form.find('button[type=submit]').prop('disabled',true),
         $spin = $form.find('.tta-admin-progress-spinner-svg').css({display:'inline-block',opacity:0}).fadeTo(200,1),
-        $resp = $('#tta-subscription-response .tta-admin-progress-response-p').removeClass('updated error').text(''),
+        $resp = $form.find('#tta-subscription-response .tta-admin-progress-response-p').removeClass('updated error').text(''),
         data  = $form.serialize() + '&action=' + action + '&nonce=' + TTA_Ajax.membership_admin_nonce;
     $.post(TTA_Ajax.ajax_url, data, function(res){
       setTimeout(function(){

--- a/docs/EventPage.md
+++ b/docs/EventPage.md
@@ -49,6 +49,7 @@ Logged-in members instead see links to profile info, upcoming events, past event
 ## Image Gallery
 
 Events can include additional photos displayed in an expandable gallery. The gallery uses a masonry-style layout so images of varying dimensions fit nicely together with minimal gaps.
+Each thumbnail uses the same popup script as attendee photos—clicking an image opens a larger version in an overlay.
 
 ## Archived Events
 

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -3,6 +3,8 @@
 The Member Dashboard is accessible at `/member-dashboard/` via the shortcode `[tta_member_dashboard]`.
 It presents four tabs: **Profile Info**, **Your Upcoming Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context.
 
+If a member is banned the dashboard displays a prominent notice at the top explaining the ban duration and purchases are blocked until it expires.
+
 ## Upcoming Events Tab
 
 The **Your Upcoming Events** tab lists future events you have tickets for. Each event

--- a/docs/MemberDashboard.md
+++ b/docs/MemberDashboard.md
@@ -1,7 +1,7 @@
 # Member Dashboard
 
 The Member Dashboard is accessible at `/member-dashboard/` via the shortcode `[tta_member_dashboard]`.
-It presents four tabs: **Profile Info**, **Your Upcoming Events**, **Your Past Events**, and **Billing & Membership Info**.
+It presents four tabs: **Profile Info**, **Your Upcoming Events**, **Your Past Events**, and **Billing & Membership Info**. Tooltip icons now appear before each field label for quicker context.
 
 ## Upcoming Events Tab
 

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -25,3 +25,5 @@ Below the summary is a **Manage Subscription** section. The controls are arrange
 - Each form displays its own response message directly below the submit button for clearer feedback.
 - The payment and billing fields only need to be filled out when updating the stored card information, reactivating a cancelled membership or changing levels. Cancelling does not require them.
 The payment form uses the same field layout as the public checkout page so administrators see familiar labels and the expiration field auto‑formats as they type.
+
+Each member profile form now includes a **Ban Status** control. Choose "Banned Indefinitely" or a 1‑4 week duration to prevent the member from buying tickets or memberships. A banner on their dashboard shows the ban end date.

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -10,6 +10,8 @@ The **Member History** tab is available under **Members** in the WordPress admin
 - A complete payment history table including event purchases and membership charges
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column
 
+The summary metrics, member email and notes are displayed together in a `widefat` table above the payment history for quick reference.
+
 Data is pulled from `tta_memberhistory`, `tta_transactions`, `tta_attendees` (and
 `tta_attendees_archive`), `tta_events`, `tta_events_archive`, and
 `tta_tickets_archive` to ensure attendance metrics remain accurate even after

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -10,7 +10,7 @@ The **Member History** tab is available under **Members** in the WordPress admin
 - A complete payment history table including event purchases and membership charges
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column
 
-The summary metrics, member email and notes are displayed together in a `widefat` table above the payment history for quick reference.
+The summary metrics, member email and notes appear as columns in a single-row `widefat` table above the payment history for quick reference.
 
 Data is pulled from `tta_memberhistory`, `tta_transactions`, `tta_attendees` (and
 `tta_attendees_archive`), `tta_events`, `tta_events_archive`, and

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -10,7 +10,7 @@ The **Member History** tab is available under **Members** in the WordPress admin
 - A complete payment history table including event purchases and membership charges
 - Any private notes stored with the member record appear in the expanded detail view rather than as a table column
 
-The summary metrics, member email and notes appear as columns in a single-row `widefat` table above the payment history for quick reference.
+The summary metrics, member email and notes appear as columns in a single-row `widefat` table above the payment history for quick reference. The “Member Summary” heading also includes a tooltip describing the data shown.
 
 Data is pulled from `tta_memberhistory`, `tta_transactions`, `tta_attendees` (and
 `tta_attendees_archive`), `tta_events`, `tta_events_archive`, and

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -17,7 +17,7 @@ Data is pulled from `tta_memberhistory`, `tta_transactions`, `tta_attendees` (an
 `tta_tickets_archive` to ensure attendance metrics remain accurate even after
 events are removed.
 
-Below the summary is a **Manage Subscription** section. The controls are arranged side-by-side for quick access and each heading includes a tooltip describing its purpose. Administrators can:
+Below the summary is a **Manage Subscription** section. The controls are arranged side-by-side for quick access and each heading includes a tooltip describing its purpose. Tooltip icons come before each heading for improved readability. Administrators can:
 
 - Update the stored payment method and billing address for the member's recurring Authorize.Net subscription.
 - Cancel or reactivate the subscription without leaving WordPress.

--- a/docs/MemberHistoryAdmin.md
+++ b/docs/MemberHistoryAdmin.md
@@ -22,6 +22,6 @@ Below the summary is a **Manage Subscription** section. The controls are arrange
 - Update the stored payment method and billing address for the member's recurring Authorize.Net subscription.
 - Cancel or reactivate the subscription without leaving WordPress.
 - Change the membership level and specify a custom monthly price. The update attempts to modify the existing subscription via Authorize.Net; on failure a clear error message is returned.
-- All actions share a single response area below the forms so status messages stay in one place.
+- Each form displays its own response message directly below the submit button for clearer feedback.
 - The payment and billing fields only need to be filled out when updating the stored card information, reactivating a cancelled membership or changing levels. Cancelling does not require them.
 The payment form uses the same field layout as the public checkout page so administrators see familiar labels and the expiration field auto‑formats as they type.

--- a/docs/ProfilePopup.md
+++ b/docs/ProfilePopup.md
@@ -2,7 +2,7 @@
 
 Elements with the `tta-popup-img` class display a larger version in a simple overlay when clicked. The popup is handled by `profile-popup.js` and disabled automatically when the viewport width is 480px or less.
 
-The script and its accompanying stylesheet are loaded on both the Event Page and Events List templates. To use it elsewhere simply add the class and optional `data-full` attribute to an image element:
+The script and its accompanying stylesheet are loaded on the Event Page, Events List template, and the admin Event screens. To use it elsewhere simply add the class and optional `data-full` attribute to an image element:
 
 ```html
 <img src="thumbnail.jpg" data-full="large.jpg" class="tta-popup-img" alt="Profile">

--- a/includes/admin/views/events-create.php
+++ b/includes/admin/views/events-create.php
@@ -541,7 +541,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
          <!-- Event Description -->
         <tr style="width: 100%;">
           <th>
-            <h2>Event Description</h2>
+            <h2>
+              <span class="tta-tooltip-icon" data-tooltip="Describe the event details shown on the public page.">
+                <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+              </span>
+              <?php esc_html_e( 'Event Description', 'tta' ); ?>
+            </h2>
           </th>
           <td style="width: 100vw;">
             <?php

--- a/includes/admin/views/events-create.php
+++ b/includes/admin/views/events-create.php
@@ -434,7 +434,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             </td>
         </tr>
         <tr>
-            <th><label for="discount_type">Discount Type</label></th>
+            <th>
+                <span class="tta-tooltip-icon" data-tooltip="Select whether the discount is a flat amount or percentage.">
+                    <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
+                </span>
+                <label for="discount_type">Discount Type</label>
+            </th>
             <td>
                 <select name="discount_type" id="discount_type">
                     <option value="flat" <?php selected($event['discount_type']??'percent','flat'); ?>>Flat $ Amount Off</option>
@@ -443,7 +448,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             </td>
         </tr>
         <tr>
-            <th><label for="discount_amount">Discount Amount</label></th>
+            <th>
+                <span class="tta-tooltip-icon" data-tooltip="Numeric amount of the discount. Percentage will use this value as percent.">
+                    <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
+                </span>
+                <label for="discount_amount">Discount Amount</label>
+            </th>
             <td>
                 <input type="number" name="discount_amount" id="discount_amount" step="0.01" min="0"
                        value="<?php echo esc_attr($event['discount_amount']??0); ?>">

--- a/includes/admin/views/events-create.php
+++ b/includes/admin/views/events-create.php
@@ -115,10 +115,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Event Name -->
         <tr>
             <th>
-                <label for="name">Event Name</label>
                 <span class="tta-tooltip-icon" data-tooltip="Enter the title of the event as it will appear everywhere.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="name">Event Name</label>
             </th>
             <td>
                 <input type="text" name="name" id="name" class="regular-text"
@@ -130,10 +130,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Date -->
         <tr>
             <th>
-                <label for="date">Date</label>
                 <span class="tta-tooltip-icon" data-tooltip="Choose the calendar date for this event.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="date">Date</label>
             </th>
             <td>
                 <input type="date" name="date" id="date"
@@ -144,10 +144,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- All-day Event? -->
         <tr>
             <th>
-                <label for="all_day_event">All-day Event?</label>
                 <span class="tta-tooltip-icon" data-tooltip="Check ‘Yes’ if the event spans the entire day.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="all_day_event">All-day Event?</label>
             </th>
             <td>
                 <select name="all_day_event" id="all_day_event">
@@ -160,10 +160,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Start Time -->
         <tr>
             <th>
-                <label for="start_time">Start Time</label>
                 <span class="tta-tooltip-icon" data-tooltip="Use the time picker to select the event start time.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="start_time">Start Time</label>
             </th>
             <td>
                 <input type="time" name="start_time" id="start_time" class="regular-text"
@@ -174,10 +174,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- End Time -->
         <tr>
             <th>
-                <label for="end_time">End Time</label>
                 <span class="tta-tooltip-icon" data-tooltip="Use the time picker to select the event end time.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="end_time">End Time</label>
             </th>
             <td>
                 <input type="time" name="end_time" id="end_time" class="regular-text"
@@ -188,10 +188,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Virtual Event? -->
         <tr>
             <th>
-                <label for="virtual_event">Virtual Event?</label>
                 <span class="tta-tooltip-icon" data-tooltip="Check ‘Yes’ if this is an online-only event.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="virtual_event">Virtual Event?</label>
             </th>
             <td>
                 <select name="virtual_event" id="virtual_event">
@@ -204,10 +204,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Street Address -->
         <tr>
             <th>
-                <label for="street_address">Street Address</label>
                 <span class="tta-tooltip-icon" data-tooltip="Enter the primary street address.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="street_address">Street Address</label>
             </th>
             <td>
                 <input type="text" name="street_address" id="street_address" class="regular-text"
@@ -218,10 +218,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Address 2 -->
         <tr>
             <th>
-                <label for="address_2">Address 2</label>
                 <span class="tta-tooltip-icon" data-tooltip="Apartment, suite, unit, etc.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="address_2">Address 2</label>
             </th>
             <td>
                 <input type="text" name="address_2" id="address_2" class="regular-text"
@@ -232,10 +232,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- City -->
         <tr>
             <th>
-                <label for="city">City</label>
                 <span class="tta-tooltip-icon" data-tooltip="City name.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="city">City</label>
             </th>
             <td>
                 <input type="text" name="city" id="city" class="regular-text"
@@ -246,10 +246,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- State -->
         <tr>
             <th>
-                <label for="state">State</label>
                 <span class="tta-tooltip-icon" data-tooltip="Select the state for this event location.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="state">State</label>
             </th>
             <td>
                 <?php
@@ -279,10 +279,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- ZIP -->
         <tr>
             <th>
-                <label for="zip">ZIP</label>
                 <span class="tta-tooltip-icon" data-tooltip="Postal code.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="zip">ZIP</label>
             </th>
             <td>
                 <input type="text" name="zip" id="zip" class="regular-text"
@@ -293,10 +293,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Venue Name -->
         <tr>
             <th>
-                <label for="venuename">Venue Name</label>
                 <span class="tta-tooltip-icon" data-tooltip="The name of the Venue">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="venuename">Venue Name</label>
             </th>
             <td>
                 <input type="text" name="venuename" id="venuename" class="regular-text"
@@ -307,10 +307,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Venue Link -->
         <tr>
             <th>
-                <label for="venueurl">Venue Link</label>
                 <span class="tta-tooltip-icon" data-tooltip="Link to the venue or event page.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="venueurl">Venue Link</label>
             </th>
             <td>
                 <input type="url" name="venueurl" id="venueurl" class="regular-text"
@@ -321,10 +321,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Event Type -->
         <tr>
             <th>
-                <label for="type">Event Type</label>
                 <span class="tta-tooltip-icon" data-tooltip="Select the membership requirement for this event. Open Events are public. Basic Membership Required means attendees must be logged in with at least a Basic membership. Premium Membership Required limits access to Premium members only.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="type">Event Type</label>
             </th>
             <td>
                 <select name="type" id="type">
@@ -349,10 +349,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Base Cost -->
         <tr>
             <th>
-                <label for="baseeventcost">Base Cost</label>
                 <span class="tta-tooltip-icon" data-tooltip="Enter the standard ticket price in USD, with cents.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="baseeventcost">Base Cost</label>
             </th>
             <td>
                 <input type="number" name="baseeventcost" id="baseeventcost" class="regular-text" step="0.01" min="0"
@@ -363,10 +363,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Basic Member Cost -->
         <tr>
             <th>
-                <label for="discountedmembercost">Basic Member Cost</label>
                 <span class="tta-tooltip-icon" data-tooltip="Enter the basic member discounted price in USD, with cents.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="discountedmembercost">Basic Member Cost</label>
             </th>
             <td>
                 <input type="number" name="discountedmembercost" id="discountedmembercost" class="regular-text" step="0.01" min="0"
@@ -377,10 +377,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
          <!-- Premium Member Cost -->
         <tr>
             <th>
-                <label for="premiummembercost">Premium Member Cost</label>
                 <span class="tta-tooltip-icon" data-tooltip="Enter the premium member discounted price in USD, with cents.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="premiummembercost">Premium Member Cost</label>
             </th>
             <td>
                 <input type="number" name="premiummembercost" id="premiummembercost" class="regular-text" step="0.01" min="0"
@@ -391,10 +391,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Waitlist Available? -->
         <tr>
             <th>
-                <label for="waitlistavailable">Waitlist Available?</label>
                 <span class="tta-tooltip-icon" data-tooltip="Allow users to join a waitlist when the event is full.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="waitlistavailable">Waitlist Available?</label>
             </th>
             <td>
                 <select name="waitlistavailable" id="waitlistavailable">
@@ -407,10 +407,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Refunds Available? -->
         <tr>
             <th>
-                <label for="refundsavailable">Refunds Available?</label>
                 <span class="tta-tooltip-icon" data-tooltip="Allow users to request a refund for this event.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="refundsavailable">Refunds Available?</label>
             </th>
             <td>
                 <select name="refundsavailable" id="refundsavailable">
@@ -423,10 +423,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Discount Code -->
         <tr>
             <th>
-                <label for="discountcode">Discount Code</label>
                 <span class="tta-tooltip-icon" data-tooltip="Apply a promo code and its discount details.">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="discountcode">Discount Code</label>
             </th>
             <td>
                 <input type="text" name="discountcode" id="discountcode" class="regular-text"
@@ -453,10 +453,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Extra Event Link 1 -->
         <tr>
             <th>
-                <label for="url2">Extra Event Link 1</label>
                 <span class="tta-tooltip-icon" data-tooltip="Additional resource link (e.g., registration page).">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="url2">Extra Event Link 1</label>
             </th>
             <td>
                 <input type="url" name="url2" id="url2" class="regular-text"
@@ -467,10 +467,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Extra Event Link 2 -->
         <tr>
             <th>
-                <label for="url3">Extra Event Link 2</label>
                 <span class="tta-tooltip-icon" data-tooltip="Additional resource link (e.g., seating chart).">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="url3">Extra Event Link 2</label>
             </th>
             <td>
                 <input type="url" name="url3" id="url3" class="regular-text"
@@ -481,10 +481,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Extra Event Link 3 -->
         <tr>
             <th>
-                <label for="url4">Extra Event Link 3</label>
                 <span class="tta-tooltip-icon" data-tooltip="Additional resource link (e.g., sponsor page).">
                     <img src="<?php echo esc_url(TTA_PLUGIN_URL.'assets/images/admin/question.svg');?>" alt="Help">
                 </span>
+                <label for="url4">Extra Event Link 3</label>
             </th>
             <td>
                 <input type="url" name="url4" id="url4" class="regular-text"
@@ -495,10 +495,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Event Hosts -->
         <tr>
             <th>
-                <label for="hosts">Event Hosts</label>
                 <span class="tta-tooltip-icon" data-tooltip="Add one or more hosts.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="hosts">Event Hosts</label>
             </th>
             <td>
                 <div id="hosts-container">
@@ -518,10 +518,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Event Volunteers -->
         <tr>
             <th>
-                <label for="volunteers">Event Volunteers</label>
                 <span class="tta-tooltip-icon" data-tooltip="Add volunteers assisting with this event.">
                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                 </span>
+                <label for="volunteers">Event Volunteers</label>
             </th>
             <td>
                 <div id="volunteers-container">

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -62,13 +62,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Event Name -->
             <tr>
                 <th>
-                    <label for="name">Event Name</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Enter the title of the event as it will appear everywhere."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="name">Event Name</label>
                 </th>
                 <td>
                     <input type="text" name="name" id="name" class="regular-text"

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -544,7 +544,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
         <!-- Event Description (TinyMCE) -->
         <tr style="width:100%;">
           <th>
-            <h2>Event Description</h2>
+            <h2>
+              <span class="tta-tooltip-icon" data-tooltip="Describe the event details shown on the public page.">
+                <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+              </span>
+              <?php esc_html_e( 'Event Description', 'tta' ); ?>
+            </h2>
           </th>
           <td style="width:100vw;">
             <?php

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -80,13 +80,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Date -->
             <tr>
                 <th>
-                    <label for="date">Date</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Choose the calendar date for this event."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="date">Date</label>
                 </th>
                 <td>
                     <input type="date" name="date" id="date"
@@ -97,13 +97,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- All-day Event? -->
             <tr>
                 <th>
-                    <label for="all_day_event">All-day Event?</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Check ‘Yes’ if the event spans the entire day."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="all_day_event">All-day Event?</label>
                 </th>
                 <td>
                     <select name="all_day_event" id="all_day_event">
@@ -116,13 +116,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Start Time -->
             <tr>
                 <th>
-                    <label for="start_time">Start Time</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Use the time picker to select the event start time."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="start_time">Start Time</label>
                 </th>
                 <td>
                     <input type="time" name="start_time" id="start_time" class="regular-text"
@@ -133,13 +133,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- End Time -->
             <tr>
                 <th>
-                    <label for="end_time">End Time</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Use the time picker to select the event end time."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="end_time">End Time</label>
                 </th>
                 <td>
                     <input type="time" name="end_time" id="end_time" class="regular-text"
@@ -150,13 +150,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Virtual Event? -->
             <tr>
                 <th>
-                    <label for="virtual_event">Virtual Event?</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Check ‘Yes’ if this is an online-only event."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="virtual_event">Virtual Event?</label>
                 </th>
                 <td>
                     <select name="virtual_event" id="virtual_event">
@@ -175,13 +175,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Street Address -->
             <tr>
                 <th>
-                    <label for="street_address">Street Address</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Enter the primary street address."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="street_address">Street Address</label>
                 </th>
                 <td>
                     <input type="text" name="street_address" id="street_address" class="regular-text"
@@ -192,13 +192,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Address 2 -->
             <tr>
                 <th>
-                    <label for="address_2">Address 2</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Apartment, suite, unit, etc."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="address_2">Address 2</label>
                 </th>
                 <td>
                     <input type="text" name="address_2" id="address_2" class="regular-text"
@@ -209,13 +209,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- City -->
             <tr>
                 <th>
-                    <label for="city">City</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="City name."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="city">City</label>
                 </th>
                 <td>
                     <input type="text" name="city" id="city" class="regular-text"
@@ -226,13 +226,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- State -->
             <tr>
                 <th>
-                    <label for="state">State</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Select the state."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="state">State</label>
                 </th>
                 <td>
                     <?php
@@ -262,13 +262,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- ZIP -->
             <tr>
                 <th>
-                    <label for="zip">ZIP</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Postal code."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="zip">ZIP</label>
                 </th>
                 <td>
                     <input type="text" name="zip" id="zip" class="regular-text"
@@ -279,13 +279,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Venue Name -->
             <tr>
                 <th>
-                    <label for="venuename">Venue Name</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="The name of the Venue"
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="venuename">Venue Name</label>
                 </th>
                 <td>
                     <input type="text" name="venuename" id="venuename" class="regular-text"
@@ -296,13 +296,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Venue Link -->
             <tr>
                 <th>
-                    <label for="venueurl">Venue Link</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Link to the venue or event page."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="venueurl">Venue Link</label>
                 </th>
                 <td>
                     <input type="url" name="venueurl" id="venueurl" class="regular-text"
@@ -313,13 +313,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Event Type -->
             <tr>
                 <th>
-                    <label for="type">Event Type</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Select the membership requirement for this event. Open Events are public. Basic Membership Required means attendees must be logged in with at least a Basic membership. Premium Membership Required limits access to Premium members only."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="type">Event Type</label>
                 </th>
                 <td>
                     <select name="type" id="type">
@@ -345,13 +345,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Base Cost -->
             <tr>
                 <th>
-                    <label for="baseeventcost">Base Cost</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Standard ticket price in USD."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="baseeventcost">Base Cost</label>
                 </th>
                 <td>
                     <input type="number" name="baseeventcost" id="baseeventcost" class="regular-text"
@@ -363,13 +363,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Basic Member Cost -->
             <tr>
                 <th>
-                    <label for="discountedmembercost">Basic Member Cost</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Enter the basic member discounted price in USD, with cents."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="discountedmembercost">Basic Member Cost</label>
                 </th>
                 <td>
                     <input type="number" name="discountedmembercost" id="discountedmembercost" class="regular-text"
@@ -381,13 +381,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Premium Member Cost -->
             <tr>
                 <th>
-                    <label for="premiummembercost">Premium Member Cost</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Enter the premium member discounted price in USD, with cents."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="premiummembercost">Premium Member Cost</label>
                 </th>
                 <td>
                     <input type="number" name="premiummembercost" id="premiummembercost" class="regular-text"
@@ -399,13 +399,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Waitlist Available? -->
             <tr>
                 <th>
-                    <label for="waitlistavailable">Waitlist Available?</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Allow joining waitlist when full."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="waitlistavailable">Waitlist Available?</label>
                 </th>
                 <td>
                     <select name="waitlistavailable" id="waitlistavailable">
@@ -418,13 +418,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Refunds Available? -->
             <tr>
                 <th>
-                    <label for="refundsavailable">Refunds Available?</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Allow refund requests."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="refundsavailable">Refunds Available?</label>
                 </th>
                 <td>
                     <select name="refundsavailable" id="refundsavailable">
@@ -437,13 +437,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Discount Code -->
             <tr>
                 <th>
-                    <label for="discountcode">Discount Code</label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Promo code & discount details."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="discountcode">Discount Code</label>
                 </th>
                 <td>
                     <input type="text" name="discountcode" id="discountcode" class="regular-text"
@@ -471,13 +471,13 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <?php for ( $i = 2; $i <= 4; $i++ ) : ?>
             <tr>
                 <th>
-                    <label for="url<?php echo $i; ?>">Extra Event Link <?php echo $i - 1; ?></label>
                     <span class="tta-tooltip-icon"
                           data-tooltip="Additional resource link."
                           style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                              alt="Help">
                     </span>
+                    <label for="url<?php echo $i; ?>">Extra Event Link <?php echo $i - 1; ?></label>
                 </th>
                 <td>
                     <input type="url" name="url<?php echo $i; ?>" id="url<?php echo $i; ?>" class="regular-text"
@@ -490,10 +490,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Event Hosts -->
             <tr>
                 <th>
-                    <label for="hosts">Event Hosts</label>
                     <span class="tta-tooltip-icon" data-tooltip="Add one or more hosts." style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="hosts">Event Hosts</label>
                 </th>
                 <td>
                     <div id="hosts-container">
@@ -513,10 +513,10 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
             <!-- Event Volunteers -->
             <tr>
                 <th>
-                    <label for="volunteers">Event Volunteers</label>
                     <span class="tta-tooltip-icon" data-tooltip="Add volunteers assisting with this event." style="margin-left:4px;">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="volunteers">Event Volunteers</label>
                 </th>
                 <td>
                     <div id="volunteers-container">

--- a/includes/admin/views/events-edit.php
+++ b/includes/admin/views/events-edit.php
@@ -451,7 +451,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
                 </td>
             </tr>
             <tr>
-                <th><label for="discount_type">Discount Type</label></th>
+                <th>
+                    <span class="tta-tooltip-icon" data-tooltip="Select whether the discount is a flat amount or percentage.">
+                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
+                    </span>
+                    <label for="discount_type">Discount Type</label>
+                </th>
                 <td>
                     <select name="discount_type" id="discount_type">
                         <option value="flat" <?php selected( $event['discount_type'] ?? 'percent', 'flat' ); ?>>Flat $ Amount Off</option>
@@ -460,7 +465,12 @@ $volunteers = ! empty( $event['volunteers'] ) ? array_map( 'trim', explode( ',',
                 </td>
             </tr>
             <tr>
-                <th><label for="discount_amount">Discount Amount</label></th>
+                <th>
+                    <span class="tta-tooltip-icon" data-tooltip="Numeric amount of the discount. Percentage will use this value as percent.">
+                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
+                    </span>
+                    <label for="discount_amount">Discount Amount</label>
+                </th>
                 <td>
                     <input type="number" name="discount_amount" id="discount_amount" step="0.01" min="0"
                            value="<?php echo esc_attr( $event['discount_amount'] ?? 0 ); ?>">

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -161,6 +161,7 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
         <button type="submit" class="button"><?php esc_html_e( 'Update Payment Method', 'tta' ); ?></button>
         <div class="tta-admin-progress-spinner-div"><img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="" style="display:none;opacity:0"></div>
       </div>
+      <div id="tta-subscription-response" class="tta-admin-progress-response-div"><p class="tta-admin-progress-response-p"></p></div>
     </p>
   </form>
 
@@ -177,6 +178,7 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
         <button type="submit" class="button"><?php esc_html_e( 'Cancel This Member\'s Subscription', 'tta' ); ?></button>
         <div class="tta-admin-progress-spinner-div"><img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="" style="display:none;opacity:0"></div>
       </div>
+      <div id="tta-subscription-response" class="tta-admin-progress-response-div"><p class="tta-admin-progress-response-p"></p></div>
     </p>
   </form>
 
@@ -257,6 +259,7 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
         <button type="submit" class="button"><?php esc_html_e( 'Reactivate this Member\'s Subscription', 'tta' ); ?></button>
         <div class="tta-admin-progress-spinner-div"><img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="" style="display:none;opacity:0"></div>
       </div>
+      <div id="tta-subscription-response" class="tta-admin-progress-response-div"><p class="tta-admin-progress-response-p"></p></div>
     </p>
   </form>
 
@@ -288,9 +291,8 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
         <button type="submit" class="button"><?php esc_html_e( 'Update Membership Level', 'tta' ); ?></button>
         <div class="tta-admin-progress-spinner-div"><img class="tta-admin-progress-spinner-svg" src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ); ?>" alt="" style="display:none;opacity:0"></div>
       </div>
+      <div id="tta-subscription-response" class="tta-admin-progress-response-div"><p class="tta-admin-progress-response-p"></p></div>
     </p>
   </form>
   </div>
-
-  <div id="tta-subscription-response" class="tta-admin-progress-response-div"><p class="tta-admin-progress-response-p"></p></div>
 </div>

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -13,7 +13,12 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 ?>
 <div class="tta-member-history-details">
   <h3><?php echo esc_html( $member['first_name'] . ' ' . $member['last_name'] ); ?></h3>
-  <h4><?php esc_html_e( 'Member Summary', 'tta' ); ?></h4>
+  <h4>
+    <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Summary of spending, attendance and notes for this member.', 'tta' ); ?>">
+      <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+    </span>
+    <?php esc_html_e( 'Member Summary', 'tta' ); ?>
+  </h4>
   <table class="widefat striped">
     <thead>
       <tr>

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -44,10 +44,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
   </table>
   <?php if ( $billing_history ) : ?>
   <h4>
-    <?php esc_html_e( 'Payment History', 'tta' ); ?>
     <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Full record of all event purchases and membership payments.', 'tta' ); ?>">
       <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
     </span>
+    <?php esc_html_e( 'Payment History', 'tta' ); ?>
   </h4>
     <table class="widefat striped tta-billing-history">
       <thead>
@@ -78,10 +78,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
   <?php endif; ?>
 
   <h4>
-    <?php esc_html_e( 'Manage Subscription', 'tta' ); ?>
     <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Update payment methods, cancel, reactivate or change membership level.', 'tta' ); ?>">
       <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
     </span>
+    <?php esc_html_e( 'Manage Subscription', 'tta' ); ?>
   </h4>
 
   <p class="description">
@@ -92,10 +92,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 
   <form id="tta-admin-update-payment-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
     <h5>
-      <?php esc_html_e( 'Update Payment Method', 'tta' ); ?>
       <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Change the card and billing address used for the member\'s recurring payments.', 'tta' ); ?>">
         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
       </span>
+      <?php esc_html_e( 'Update Payment Method', 'tta' ); ?>
     </h5>
     <input type="hidden" name="member_id" value="<?php echo esc_attr( $member_id ); ?>">
     <p>
@@ -166,10 +166,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 
   <form id="tta-admin-cancel-subscription-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
     <h5>
-      <?php esc_html_e( 'Cancel Subscription', 'tta' ); ?>
       <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Immediately cancel the member\'s active subscription.', 'tta' ); ?>">
         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
       </span>
+      <?php esc_html_e( 'Cancel Subscription', 'tta' ); ?>
     </h5>
     <input type="hidden" name="member_id" value="<?php echo esc_attr( $member_id ); ?>">
     <p class="submit">
@@ -182,10 +182,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 
   <form id="tta-admin-reactivate-subscription-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
     <h5>
-      <?php esc_html_e( 'Reactivate Subscription', 'tta' ); ?>
       <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Restart billing for a cancelled member. A new subscription may be created if needed.', 'tta' ); ?>">
         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
       </span>
+      <?php esc_html_e( 'Reactivate Subscription', 'tta' ); ?>
     </h5>
     <input type="hidden" name="member_id" value="<?php echo esc_attr( $member_id ); ?>">
     <p>
@@ -262,10 +262,10 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 
   <form id="tta-admin-change-level-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
     <h5>
-      <?php esc_html_e( 'Change Membership Level', 'tta' ); ?>
       <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Switch the member between Basic and Premium tiers starting on their next bill.', 'tta' ); ?>">
         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
       </span>
+      <?php esc_html_e( 'Change Membership Level', 'tta' ); ?>
     </h5>
     <input type="hidden" name="member_id" value="<?php echo esc_attr( $member_id ); ?>">
     <p>

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -15,37 +15,31 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
   <h3><?php echo esc_html( $member['first_name'] . ' ' . $member['last_name'] ); ?></h3>
   <h4><?php esc_html_e( 'Member Summary', 'tta' ); ?></h4>
   <table class="widefat striped">
-    <tbody>
+    <thead>
       <tr>
         <th><?php esc_html_e( 'Total Spent', 'tta' ); ?></th>
-        <td>$<?php echo esc_html( number_format( $summary['total_spent'], 2 ) ); ?></td>
-      </tr>
-      <tr>
         <th><?php esc_html_e( 'Events Attended', 'tta' ); ?></th>
-        <td><?php echo esc_html( $summary['attended'] ); ?></td>
-      </tr>
-      <tr>
         <th><?php esc_html_e( 'No-Shows', 'tta' ); ?></th>
-        <td><?php echo esc_html( $summary['no_show'] ); ?></td>
-      </tr>
-      <tr>
         <th><?php esc_html_e( 'Refund/Cancellation Requests', 'tta' ); ?></th>
-        <td><?php echo esc_html( $summary['refunds'] + $summary['cancellations'] ); ?></td>
-      </tr>
-      <tr>
         <th><?php esc_html_e( 'Total Events Purchased', 'tta' ); ?></th>
-        <td><?php echo esc_html( $summary['events'] ); ?></td>
-      </tr>
-      <tr>
         <th><?php esc_html_e( 'Email', 'tta' ); ?></th>
-        <td><?php echo esc_html( $member['email'] ); ?></td>
+        <?php if ( ! empty( $member['notes'] ) ) : ?>
+          <th><?php esc_html_e( 'Notes', 'tta' ); ?></th>
+        <?php endif; ?>
       </tr>
-      <?php if ( ! empty( $member['notes'] ) ) : ?>
+    </thead>
+    <tbody>
       <tr>
-        <th><?php esc_html_e( 'Notes', 'tta' ); ?></th>
-        <td><?php echo esc_html( $member['notes'] ); ?></td>
+        <td>$<?php echo esc_html( number_format( $summary['total_spent'], 2 ) ); ?></td>
+        <td><?php echo esc_html( $summary['attended'] ); ?></td>
+        <td><?php echo esc_html( $summary['no_show'] ); ?></td>
+        <td><?php echo esc_html( $summary['refunds'] + $summary['cancellations'] ); ?></td>
+        <td><?php echo esc_html( $summary['events'] ); ?></td>
+        <td><?php echo esc_html( $member['email'] ); ?></td>
+        <?php if ( ! empty( $member['notes'] ) ) : ?>
+          <td><?php echo esc_html( $member['notes'] ); ?></td>
+        <?php endif; ?>
       </tr>
-      <?php endif; ?>
     </tbody>
   </table>
   <?php if ( $billing_history ) : ?>

--- a/includes/admin/views/member-history-details.php
+++ b/includes/admin/views/member-history-details.php
@@ -13,18 +13,41 @@ $billing_history = tta_get_member_billing_history( $member['wpuserid'] );
 ?>
 <div class="tta-member-history-details">
   <h3><?php echo esc_html( $member['first_name'] . ' ' . $member['last_name'] ); ?></h3>
-  <p><?php echo esc_html( $member['email'] ); ?></p>
-  <?php if ( ! empty( $member['notes'] ) ) : ?>
-    <p class="tta-member-notes"><strong><?php esc_html_e( 'Notes:', 'tta' ); ?></strong> <?php echo esc_html( $member['notes'] ); ?></p>
-  <?php endif; ?>
   <h4><?php esc_html_e( 'Member Summary', 'tta' ); ?></h4>
-  <ul>
-    <li><?php printf( esc_html__( 'Total Spent: $%s', 'tta' ), number_format( $summary['total_spent'], 2 ) ); ?></li>
-    <li><?php printf( esc_html__( 'Events Attended: %d', 'tta' ), $summary['attended'] ); ?></li>
-    <li><?php printf( esc_html__( 'No-Shows: %d', 'tta' ), $summary['no_show'] ); ?></li>
-    <li><?php printf( esc_html__( 'Refund/Cancellation Requests: %d', 'tta' ), $summary['refunds'] + $summary['cancellations'] ); ?></li>
-    <li><?php printf( esc_html__( 'Total Events Purchased: %d', 'tta' ), $summary['events'] ); ?></li>
-  </ul>
+  <table class="widefat striped">
+    <tbody>
+      <tr>
+        <th><?php esc_html_e( 'Total Spent', 'tta' ); ?></th>
+        <td>$<?php echo esc_html( number_format( $summary['total_spent'], 2 ) ); ?></td>
+      </tr>
+      <tr>
+        <th><?php esc_html_e( 'Events Attended', 'tta' ); ?></th>
+        <td><?php echo esc_html( $summary['attended'] ); ?></td>
+      </tr>
+      <tr>
+        <th><?php esc_html_e( 'No-Shows', 'tta' ); ?></th>
+        <td><?php echo esc_html( $summary['no_show'] ); ?></td>
+      </tr>
+      <tr>
+        <th><?php esc_html_e( 'Refund/Cancellation Requests', 'tta' ); ?></th>
+        <td><?php echo esc_html( $summary['refunds'] + $summary['cancellations'] ); ?></td>
+      </tr>
+      <tr>
+        <th><?php esc_html_e( 'Total Events Purchased', 'tta' ); ?></th>
+        <td><?php echo esc_html( $summary['events'] ); ?></td>
+      </tr>
+      <tr>
+        <th><?php esc_html_e( 'Email', 'tta' ); ?></th>
+        <td><?php echo esc_html( $member['email'] ); ?></td>
+      </tr>
+      <?php if ( ! empty( $member['notes'] ) ) : ?>
+      <tr>
+        <th><?php esc_html_e( 'Notes', 'tta' ); ?></th>
+        <td><?php echo esc_html( $member['notes'] ); ?></td>
+      </tr>
+      <?php endif; ?>
+    </tbody>
+  </table>
   <?php if ( $billing_history ) : ?>
   <h4>
     <?php esc_html_e( 'Payment History', 'tta' ); ?>

--- a/includes/admin/views/members-create.php
+++ b/includes/admin/views/members-create.php
@@ -418,45 +418,36 @@ if ( ! defined( 'ABSPATH' ) ) {
                     </th>
                     <td>
                         <fieldset>
+                            <label>
                                 <input type="checkbox" name="opt_in_marketing_email" value="1">
-                                Marketing Emails
-                                <span class="tta-tooltip-icon"
-                                      data-tooltip="Send promotional emails and newsletters."
-                                      style="margin-left:4px;">
-                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
-                                         alt="Help">
+                                <span class="tta-tooltip-icon" data-tooltip="Send promotional emails and newsletters." style="margin-left:4px;">
+                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                                 </span>
-                            <label>
+                                <?php esc_html_e( 'Marketing Emails', 'tta' ); ?>
                             </label><br>
+
+                            <label>
                                 <input type="checkbox" name="opt_in_marketing_sms" value="1">
-                                Marketing Texts/SMS
-                                <span class="tta-tooltip-icon"
-                                      data-tooltip="Send promotional text messages."
-                                      style="margin-left:4px;">
-                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
-                                         alt="Help">
+                                <span class="tta-tooltip-icon" data-tooltip="Send promotional text messages." style="margin-left:4px;">
+                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                                 </span>
-                            <label>
+                                <?php esc_html_e( 'Marketing Texts/SMS', 'tta' ); ?>
                             </label><br>
+
+                            <label>
                                 <input type="checkbox" name="opt_in_event_update_email" value="1">
-                                Event Update Emails
-                                <span class="tta-tooltip-icon"
-                                      data-tooltip="Send event announcements via email."
-                                      style="margin-left:4px;">
-                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
-                                         alt="Help">
+                                <span class="tta-tooltip-icon" data-tooltip="Send event announcements via email." style="margin-left:4px;">
+                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
                                 </span>
-                            <label>
+                                <?php esc_html_e( 'Event Update Emails', 'tta' ); ?>
                             </label><br>
-                                <input type="checkbox" name="opt_in_event_update_sms" value="1">
-                                Event Update Texts/SMS
-                                <span class="tta-tooltip-icon"
-                                      data-tooltip="Send event announcements via text message."
-                                      style="margin-left:4px;">
-                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
-                                         alt="Help">
-                                </span>
+
                             <label>
+                                <input type="checkbox" name="opt_in_event_update_sms" value="1">
+                                <span class="tta-tooltip-icon" data-tooltip="Send event announcements via text message." style="margin-left:4px;">
+                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+                                </span>
+                                <?php esc_html_e( 'Event Update Texts/SMS', 'tta' ); ?>
                             </label>
                         </fieldset>
                     </td>

--- a/includes/admin/views/members-create.php
+++ b/includes/admin/views/members-create.php
@@ -467,10 +467,31 @@ if ( ! defined( 'ABSPATH' ) ) {
                     <td>
                         <fieldset>
                             <label>
+                                <span class="tta-tooltip-icon" data-tooltip="Hide this member from public attendee lists.">
+                                    <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+                                </span>
                                 <input type="checkbox" name="hide_event_attendance" value="1">
                                 Hide Event Attendance
                             </label>
                         </fieldset>
+                    </td>
+                </tr>
+                <tr>
+                    <th>
+                        <span class="tta-tooltip-icon" data-tooltip="Prevent this member from making purchases.">
+                            <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help">
+                        </span>
+                        <label for="ban_status">Ban Status</label>
+                    </th>
+                    <td>
+                        <select name="ban_status" id="ban_status">
+                            <option value="none">Not Banned</option>
+                            <option value="indefinite">Banned Indefinitely</option>
+                            <option value="1week">1-Week Ban</option>
+                            <option value="2week">2-Week Ban</option>
+                            <option value="3week">3-Week Ban</option>
+                            <option value="4week">4-Week Ban</option>
+                        </select>
                     </td>
                 </tr>
 

--- a/includes/admin/views/members-create.php
+++ b/includes/admin/views/members-create.php
@@ -12,13 +12,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- First Name -->
                 <tr>
                     <th>
-                        <label for="first_name">First Name</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the member’s first name."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="first_name">First Name</label>
                     </th>
                     <td>
                         <input type="text" name="first_name" id="first_name" class="regular-text" required>
@@ -28,13 +28,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Last Name -->
                 <tr>
                     <th>
-                        <label for="last_name">Last Name</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the member’s last name."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="last_name">Last Name</label>
                     </th>
                     <td>
                         <input type="text" name="last_name" id="last_name" class="regular-text" required>
@@ -44,13 +44,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Email Address -->
                 <tr>
                     <th>
-                        <label for="email">Email Address</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter a valid email address; a verification will follow."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="email">Email Address</label>
                     </th>
                     <td>
                         <input type="email" name="email" id="email" class="regular-text" required>
@@ -60,13 +60,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Verify Email Address -->
                 <tr>
                     <th>
-                        <label for="email_verify">Verify Email Address</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Re-enter the same email address to confirm."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="email_verify">Verify Email Address</label>
                     </th>
                     <td>
                         <input type="email" name="email_verify" id="email_verify" class="regular-text" required>
@@ -76,13 +76,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Street Address -->
                 <tr>
                     <th>
-                        <label for="street_address">Street Address</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the primary street address."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="street_address">Street Address</label>
                     </th>
                     <td>
                         <input type="text" name="street_address" id="street_address" class="regular-text">
@@ -92,13 +92,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Address 2 -->
                 <tr>
                     <th>
-                        <label for="address_2">Address 2</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Apt, Suite, PO Box, etc. (optional)."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="address_2">Address 2</label>
                     </th>
                     <td>
                         <input type="text" name="address_2" id="address_2" class="regular-text">
@@ -108,13 +108,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- City -->
                 <tr>
                     <th>
-                        <label for="city">City</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the city name."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="city">City</label>
                     </th>
                     <td>
                         <input type="text" name="city" id="city" class="regular-text">
@@ -124,13 +124,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- State -->
                 <tr>
                     <th>
-                        <label for="state">State</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Select the state."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="state">State</label>
                     </th>
                     <td>
                         <select name="state" id="state">
@@ -162,13 +162,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- ZIP -->
                 <tr>
                     <th>
-                        <label for="zip">ZIP</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the 5-digit ZIP code."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="zip">ZIP</label>
                     </th>
                     <td>
                         <input type="text" name="zip" id="zip" class="regular-text" maxlength="10">
@@ -178,13 +178,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Phone Number -->
                 <tr>
                     <th>
-                        <label for="phone">Phone Number</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter a 10-digit phone number; it will format automatically."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="phone">Phone Number</label>
                     </th>
                     <td>
                         <input type="tel" name="phone" id="phone" class="regular-text" placeholder="e.g. (555) 123-4567">
@@ -194,13 +194,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Date of Birth -->
                 <tr>
                     <th>
-                        <label for="dob">Date of Birth</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Enter the member’s birth date (YYYY-MM-DD)."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="dob">Date of Birth</label>
                     </th>
                     <td>
                         <input type="date" name="dob" id="dob">
@@ -210,13 +210,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Member Type -->
                 <tr>
                     <th>
-                        <label for="member_type">Member Type</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Select the user role for this member."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="member_type">Member Type</label>
                     </th>
                     <td>
                         <select name="member_type" id="member_type">
@@ -231,13 +231,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Membership Level -->
                 <tr>
                     <th>
-                        <label for="membership_level">Membership Level</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Choose the membership tier: Free, Basic, or Premium."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="membership_level">Membership Level</label>
                     </th>
                     <td>
                         <select name="membership_level" id="membership_level">
@@ -251,13 +251,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Facebook URL -->
                 <tr>
                     <th>
-                        <label for="facebook">Facebook URL</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Full URL to the member’s Facebook profile."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="facebook">Facebook URL</label>
                     </th>
                     <td>
                         <input type="url" name="facebook" id="facebook" class="regular-text" placeholder="https://facebook.com/username">
@@ -267,13 +267,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- LinkedIn URL -->
                 <tr>
                     <th>
-                        <label for="linkedin">LinkedIn URL</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Full URL to the member’s LinkedIn profile."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="linkedin">LinkedIn URL</label>
                     </th>
                     <td>
                         <input type="url" name="linkedin" id="linkedin" class="regular-text" placeholder="https://linkedin.com/in/username">
@@ -283,13 +283,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Instagram URL -->
                 <tr>
                     <th>
-                        <label for="instagram">Instagram URL</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Full URL to the member’s Instagram profile."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="instagram">Instagram URL</label>
                     </th>
                     <td>
                         <input type="url" name="instagram" id="instagram" class="regular-text" placeholder="https://instagram.com/username">
@@ -299,13 +299,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- X/Twitter URL -->
                 <tr>
                     <th>
-                        <label for="twitter">X/Twitter URL</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Full URL to the member’s Twitter (X) profile."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="twitter">X/Twitter URL</label>
                     </th>
                     <td>
                         <input type="url" name="twitter" id="twitter" class="regular-text" placeholder="https://twitter.com/username">
@@ -315,13 +315,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Interests -->
                 <tr>
                     <th>
-                        <label for="interests">Interests</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Add one or more interests; click “+ Add Another Interest” to add more."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="interests">Interests</label>
                     </th>
                     <td>
                         <div id="interests-container">
@@ -351,13 +351,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Biography -->
                 <tr>
                     <th>
-                        <label for="biography">Biography</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="A short introduction or bio for this member."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="biography">Biography</label>
                     </th>
                     <td>
                         <textarea name="biography" id="biography" rows="5" class="large-text" placeholder="Tell us about yourself…"></textarea>
@@ -367,13 +367,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Admin Notes -->
                 <tr>
                     <th>
-                        <label for="notes">Admin Notes</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Private notes about this member (not visible to the member)."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label for="notes">Admin Notes</label>
                     </th>
                     <td>
                         <textarea name="notes" id="notes" rows="4" class="large-text" placeholder="Confidential notes…"></textarea>
@@ -383,13 +383,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Profile Image -->
                 <tr>
                     <th>
-                        <label>Profile Image</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Select or upload a profile picture for the member."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label>Profile Image</label>
                     </th>
                     <td>
                         <div class="tta-profile-image-wrapper">
@@ -408,17 +408,16 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Opt-In Preferences -->
                 <tr>
                     <th>
-                        <label>Opt-In Preferences</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Select which communications this member wants to receive."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label>Opt-In Preferences</label>
                     </th>
                     <td>
                         <fieldset>
-                            <label>
                                 <input type="checkbox" name="opt_in_marketing_email" value="1">
                                 Marketing Emails
                                 <span class="tta-tooltip-icon"
@@ -427,8 +426,8 @@ if ( ! defined( 'ABSPATH' ) ) {
                                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                          alt="Help">
                                 </span>
-                            </label><br>
                             <label>
+                            </label><br>
                                 <input type="checkbox" name="opt_in_marketing_sms" value="1">
                                 Marketing Texts/SMS
                                 <span class="tta-tooltip-icon"
@@ -437,8 +436,8 @@ if ( ! defined( 'ABSPATH' ) ) {
                                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                          alt="Help">
                                 </span>
-                            </label><br>
                             <label>
+                            </label><br>
                                 <input type="checkbox" name="opt_in_event_update_email" value="1">
                                 Event Update Emails
                                 <span class="tta-tooltip-icon"
@@ -447,8 +446,8 @@ if ( ! defined( 'ABSPATH' ) ) {
                                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                          alt="Help">
                                 </span>
-                            </label><br>
                             <label>
+                            </label><br>
                                 <input type="checkbox" name="opt_in_event_update_sms" value="1">
                                 Event Update Texts/SMS
                                 <span class="tta-tooltip-icon"
@@ -457,6 +456,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                                     <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                          alt="Help">
                                 </span>
+                            <label>
                             </label>
                         </fieldset>
                     </td>
@@ -465,13 +465,13 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <!-- Privacy Options -->
                 <tr>
                     <th>
-                        <label>Privacy Options</label>
                         <span class="tta-tooltip-icon"
                               data-tooltip="Control what information is shown publicly."
                               style="margin-left:4px;">
                             <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>"
                                  alt="Help">
                         </span>
+                        <label>Privacy Options</label>
                     </th>
                     <td>
                         <fieldset>

--- a/includes/admin/views/members-edit.php
+++ b/includes/admin/views/members-edit.php
@@ -119,10 +119,10 @@ wp_enqueue_media();
             <!-- Street Address -->
             <tr>
                 <th>
-                    <label for="street_address_edit">Street Address</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s street address.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="street_address_edit">Street Address</label>
                 </th>
                 <td>
                     <input type="text"
@@ -136,10 +136,10 @@ wp_enqueue_media();
             <!-- Address Line 2 -->
             <tr>
                 <th>
-                    <label for="address_2_edit">Address 2</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s suite, apartment, etc.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="address_2_edit">Address 2</label>
                 </th>
                 <td>
                     <input type="text"
@@ -153,10 +153,10 @@ wp_enqueue_media();
             <!-- City -->
             <tr>
                 <th>
-                    <label for="city_edit">City</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s city.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="city_edit">City</label>
                 </th>
                 <td>
                     <input type="text"
@@ -170,10 +170,10 @@ wp_enqueue_media();
             <!-- State -->
             <tr>
                 <th>
-                    <label for="state_edit">State</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s state.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="state_edit">State</label>
                 </th>
                 <td>
                     <select name="state" id="state_edit">
@@ -196,10 +196,10 @@ wp_enqueue_media();
             <!-- ZIP Code -->
             <tr>
                 <th>
-                    <label for="zip_edit">ZIP</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s ZIP code.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="zip_edit">ZIP</label>
                 </th>
                 <td>
                     <input type="text"
@@ -213,10 +213,10 @@ wp_enqueue_media();
             <!-- Phone -->
             <tr>
                 <th>
-                    <label for="phone_edit">Phone Number</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the phone number.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="phone_edit">Phone Number</label>
                 </th>
                 <td>
                     <input type="tel"
@@ -230,10 +230,10 @@ wp_enqueue_media();
             <!-- Date of Birth -->
             <tr>
                 <th>
-                    <label for="dob_edit">Date of Birth</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s birth date.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="dob_edit">Date of Birth</label>
                 </th>
                 <td>
                     <input type="date"
@@ -246,10 +246,10 @@ wp_enqueue_media();
             <!-- Member Type -->
             <tr>
                 <th>
-                    <label for="member_type_edit">Member Type</label>
                     <span class="tta-tooltip-icon" data-tooltip="Change the member’s role.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="member_type_edit">Member Type</label>
                 </th>
                 <td>
                     <select name="member_type" id="member_type_edit">
@@ -264,10 +264,10 @@ wp_enqueue_media();
             <!-- Membership Level -->
             <tr>
                 <th>
-                    <label for="membership_level_edit">Membership Level</label>
                     <span class="tta-tooltip-icon" data-tooltip="Change subscription tier.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="membership_level_edit">Membership Level</label>
                 </th>
                 <td>
                     <select name="membership_level" id="membership_level_edit">
@@ -281,10 +281,10 @@ wp_enqueue_media();
             <!-- Facebook URL -->
             <tr>
                 <th>
-                    <label for="facebook_edit">Facebook URL</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the Facebook link.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="facebook_edit">Facebook URL</label>
                 </th>
                 <td>
                     <input type="url"
@@ -298,10 +298,10 @@ wp_enqueue_media();
             <!-- LinkedIn URL -->
             <tr>
                 <th>
-                    <label for="linkedin_edit">LinkedIn URL</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the LinkedIn link.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="linkedin_edit">LinkedIn URL</label>
                 </th>
                 <td>
                     <input type="url"
@@ -315,10 +315,10 @@ wp_enqueue_media();
             <!-- Instagram URL -->
             <tr>
                 <th>
-                    <label for="instagram_edit">Instagram URL</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the Instagram link.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="instagram_edit">Instagram URL</label>
                 </th>
                 <td>
                     <input type="url"
@@ -332,10 +332,10 @@ wp_enqueue_media();
             <!-- Twitter URL -->
             <tr>
                 <th>
-                    <label for="twitter_edit">X/Twitter URL</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the Twitter (X) link.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="twitter_edit">X/Twitter URL</label>
                 </th>
                 <td>
                     <input type="url"
@@ -348,10 +348,10 @@ wp_enqueue_media();
             <!-- Interests -->
             <tr>
                 <th>
-                    <label for="interests_edit">Interests</label>
                     <span class="tta-tooltip-icon" data-tooltip="Comma-separated interests.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="interests_edit">Interests</label>
                 </th>
                 <td>
                     <div id="interests-container">
@@ -402,10 +402,10 @@ wp_enqueue_media();
             <!-- Biography -->
             <tr>
                 <th>
-                    <label for="biography_edit">Biography</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s bio.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="biography_edit">Biography</label>
                 </th>
                 <td>
                     <textarea name="biography"
@@ -419,10 +419,10 @@ wp_enqueue_media();
             <!-- Admin Notes -->
             <tr>
                 <th>
-                    <label for="notes_edit">Admin Notes</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit confidential notes.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="notes_edit">Admin Notes</label>
                 </th>
                 <td>
                     <textarea name="notes"
@@ -436,10 +436,10 @@ wp_enqueue_media();
             <!-- Profile Image -->
             <tr>
                 <th>
-                    <label>Profile Image</label>
                     <span class="tta-tooltip-icon" data-tooltip="Change profile picture.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label>Profile Image</label>
                 </th>
                 <td>
                     <div class="tta-profile-image-wrapper">
@@ -462,10 +462,10 @@ wp_enqueue_media();
             <!-- Opt-In Preferences -->
             <tr>
                 <th>
-                    <label>Opt-In Preferences</label>
                     <span class="tta-tooltip-icon" data-tooltip="Toggle communications.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label>Opt-In Preferences</label>
                 </th>
                 <td>
                     <?php
@@ -475,33 +475,33 @@ wp_enqueue_media();
                     $opt_event_update_sms      = intval( $member['opt_in_event_update_sms'] );
                     ?>
                     <fieldset>
-                        <label>
                             <input type="checkbox" name="opt_in_marketing_email" value="1" <?php checked( $opt_marketing_email, 1 ); ?>>
                             Marketing Emails
                             <span class="tta-tooltip-icon" data-tooltip="Send promotional emails and newsletters.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        </label><br>
                         <label>
+                        </label><br>
                             <input type="checkbox" name="opt_in_marketing_sms" value="1" <?php checked( $opt_marketing_sms, 1 ); ?>>
                             Marketing Texts/SMS
                             <span class="tta-tooltip-icon" data-tooltip="Send promotional text messages.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        </label><br>
                         <label>
+                        </label><br>
                             <input type="checkbox" name="opt_in_event_update_email" value="1" <?php checked( $opt_event_update_email, 1 ); ?>>
                             Event Update Emails
                             <span class="tta-tooltip-icon" data-tooltip="Send event announcements via email.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        </label><br>
                         <label>
+                        </label><br>
                             <input type="checkbox" name="opt_in_event_update_sms" value="1" <?php checked( $opt_event_update_sms, 1 ); ?>>
                             Event Update Texts/SMS
                             <span class="tta-tooltip-icon" data-tooltip="Send event announcements via text message.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
+                        <label>
                         </label>
                     </fieldset>
                 </td>
@@ -510,10 +510,10 @@ wp_enqueue_media();
             <!-- Privacy Options -->
             <tr>
                 <th>
-                    <label>Privacy Options</label>
                     <span class="tta-tooltip-icon" data-tooltip="Control what information is shown publicly.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label>Privacy Options</label>
                 </th>
                 <td>
                     <fieldset>

--- a/includes/admin/views/members-edit.php
+++ b/includes/admin/views/members-edit.php
@@ -475,33 +475,36 @@ wp_enqueue_media();
                     $opt_event_update_sms      = intval( $member['opt_in_event_update_sms'] );
                     ?>
                     <fieldset>
+                        <label>
                             <input type="checkbox" name="opt_in_marketing_email" value="1" <?php checked( $opt_marketing_email, 1 ); ?>>
-                            Marketing Emails
                             <span class="tta-tooltip-icon" data-tooltip="Send promotional emails and newsletters.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        <label>
+                            <?php esc_html_e( 'Marketing Emails', 'tta' ); ?>
                         </label><br>
+
+                        <label>
                             <input type="checkbox" name="opt_in_marketing_sms" value="1" <?php checked( $opt_marketing_sms, 1 ); ?>>
-                            Marketing Texts/SMS
                             <span class="tta-tooltip-icon" data-tooltip="Send promotional text messages.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        <label>
+                            <?php esc_html_e( 'Marketing Texts/SMS', 'tta' ); ?>
                         </label><br>
+
+                        <label>
                             <input type="checkbox" name="opt_in_event_update_email" value="1" <?php checked( $opt_event_update_email, 1 ); ?>>
-                            Event Update Emails
                             <span class="tta-tooltip-icon" data-tooltip="Send event announcements via email.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        <label>
+                            <?php esc_html_e( 'Event Update Emails', 'tta' ); ?>
                         </label><br>
+
+                        <label>
                             <input type="checkbox" name="opt_in_event_update_sms" value="1" <?php checked( $opt_event_update_sms, 1 ); ?>>
-                            Event Update Texts/SMS
                             <span class="tta-tooltip-icon" data-tooltip="Send event announcements via text message.">
                                 <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                             </span>
-                        <label>
+                            <?php esc_html_e( 'Event Update Texts/SMS', 'tta' ); ?>
                         </label>
                     </fieldset>
                 </td>

--- a/includes/admin/views/members-edit.php
+++ b/includes/admin/views/members-edit.php
@@ -47,10 +47,10 @@ wp_enqueue_media();
             <!-- First Name -->
             <tr>
                 <th>
-                    <label for="first_name_edit">First Name</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s first name.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="first_name_edit">First Name</label>
                 </th>
                 <td>
                     <input type="text"
@@ -65,10 +65,10 @@ wp_enqueue_media();
             <!-- Last Name -->
             <tr>
                 <th>
-                    <label for="last_name_edit">Last Name</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s last name.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="last_name_edit">Last Name</label>
                 </th>
                 <td>
                     <input type="text"
@@ -83,10 +83,10 @@ wp_enqueue_media();
             <!-- Email Address -->
             <tr>
                 <th>
-                    <label for="email_edit">Email Address</label>
                     <span class="tta-tooltip-icon" data-tooltip="Edit the member’s email address.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="email_edit">Email Address</label>
                 </th>
                 <td>
                     <input type="email"
@@ -101,10 +101,10 @@ wp_enqueue_media();
             <!-- Verify Email Address -->
             <tr>
                 <th>
-                    <label for="email_verify_edit">Verify Email Address</label>
                     <span class="tta-tooltip-icon" data-tooltip="Re-enter the same email to confirm.">
                         <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
                     </span>
+                    <label for="email_verify_edit">Verify Email Address</label>
                 </th>
                 <td>
                     <input type="email"

--- a/includes/admin/views/members-edit.php
+++ b/includes/admin/views/members-edit.php
@@ -521,10 +521,48 @@ wp_enqueue_media();
                 <td>
                     <fieldset>
                         <label>
+                            <span class="tta-tooltip-icon" data-tooltip="Hide this member from public attendee lists.">
+                                <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
+                            </span>
                             <input type="checkbox" name="hide_event_attendance" value="1" <?php checked( $hide_attendance, 1 ); ?>>
                             Hide Event Attendance
                         </label>
                     </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th>
+                    <span class="tta-tooltip-icon" data-tooltip="Prevent this member from making purchases.">
+                        <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/admin/question.svg' ); ?>" alt="Help" />
+                    </span>
+                    <label for="ban_status">Ban Status</label>
+                </th>
+                <td>
+                    <?php
+                    $ban_opt = 'none';
+                    if ( $member['banned_until'] ) {
+                        $diff = strtotime( $member['banned_until'] ) - time();
+                        if ( $diff > 0 ) {
+                            if ( $diff >= 2419200 ) {
+                                $ban_opt = 'indefinite';
+                            } elseif ( $diff >= 1814400 ) {
+                                $ban_opt = '3week';
+                            } elseif ( $diff >= 1209600 ) {
+                                $ban_opt = '2week';
+                            } elseif ( $diff >= 604800 ) {
+                                $ban_opt = '1week';
+                            }
+                        }
+                    }
+                    ?>
+                    <select name="ban_status" id="ban_status">
+                        <option value="none" <?php selected( $ban_opt, 'none' ); ?>>Not Banned</option>
+                        <option value="indefinite" <?php selected( $ban_opt, 'indefinite' ); ?>>Banned Indefinitely</option>
+                        <option value="1week" <?php selected( $ban_opt, '1week' ); ?>>1-Week Ban</option>
+                        <option value="2week" <?php selected( $ban_opt, '2week' ); ?>>2-Week Ban</option>
+                        <option value="3week" <?php selected( $ban_opt, '3week' ); ?>>3-Week Ban</option>
+                        <option value="4week" <?php selected( $ban_opt, '4week' ); ?>>4-Week Ban</option>
+                    </select>
                 </td>
             </tr>
 

--- a/includes/ajax/handlers/class-ajax-cart.php
+++ b/includes/ajax/handlers/class-ajax-cart.php
@@ -35,6 +35,9 @@ class TTA_Ajax_Cart {
             if ( in_array( $lvl, [ 'basic', 'premium' ], true ) ) {
                 $membership_level = $lvl;
             }
+            if ( tta_user_is_banned( get_current_user_id() ) ) {
+                wp_send_json_error( [ 'message' => __( 'You are currently banned from purchasing tickets.', 'tta' ) ] );
+            }
         }
 
         $cart = new TTA_Cart();

--- a/includes/ajax/handlers/class-ajax-members.php
+++ b/includes/ajax/handlers/class-ajax-members.php
@@ -51,6 +51,26 @@ class TTA_Ajax_Members {
         $interests     = $interests_arr ? implode( ',', $interests_arr ) : '';
 
         $hide_att      = ! empty( $_POST['hide_event_attendance'] ) ? 1 : 0;
+        $ban_status    = sanitize_text_field( $_POST['ban_status'] ?? 'none' );
+        switch ( $ban_status ) {
+            case 'indefinite':
+                $banned_until = '9999-12-31 23:59:59';
+                break;
+            case '1week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS );
+                break;
+            case '2week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 2 * WEEK_IN_SECONDS );
+                break;
+            case '3week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 3 * WEEK_IN_SECONDS );
+                break;
+            case '4week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 4 * WEEK_IN_SECONDS );
+                break;
+            default:
+                $banned_until = null;
+        }
 
         $opt_email = ! empty( $_POST['opt_in_marketing_email'] )    ? 1 : 0;
         $opt_sms   = ! empty( $_POST['opt_in_marketing_sms'] )      ? 1 : 0;
@@ -124,6 +144,7 @@ class TTA_Ajax_Members {
                 'opt_in_event_update_email' => $opt_upd_email,
                 'opt_in_event_update_sms'   => $opt_upd_sms,
                 'hide_event_attendance'     => $hide_att,
+                'banned_until'             => $banned_until,
             ],
             [
                 '%d',    // wpuserid
@@ -149,6 +170,7 @@ class TTA_Ajax_Members {
                 '%d',    // opt_in_event_update_email
                 '%d',    // opt_in_event_update_sms
                 '%d',    // hide_event_attendance
+                '%s',    // banned_until
             ]
         );
         $member_id = $wpdb->insert_id;
@@ -267,6 +289,26 @@ class TTA_Ajax_Members {
         $interests         = ! empty( $interests_arr ) ? implode( ',', $interests_arr ) : '';
 
         $hide_att         = ! empty( $_POST['hide_event_attendance'] ) ? 1 : 0;
+        $ban_status       = sanitize_text_field( $_POST['ban_status'] ?? 'none' );
+        switch ( $ban_status ) {
+            case 'indefinite':
+                $banned_until = '9999-12-31 23:59:59';
+                break;
+            case '1week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS );
+                break;
+            case '2week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 2 * WEEK_IN_SECONDS );
+                break;
+            case '3week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 3 * WEEK_IN_SECONDS );
+                break;
+            case '4week':
+                $banned_until = date( 'Y-m-d H:i:s', time() + 4 * WEEK_IN_SECONDS );
+                break;
+            default:
+                $banned_until = null;
+        }
 
         // Opt-ins
         $opt_email         = ! empty( $_POST['opt_in_marketing_email'] )    ? 1 : 0;
@@ -306,6 +348,7 @@ class TTA_Ajax_Members {
             'hide_event_attendance'     => $hide_att,
             'member_type'               => $member_type,
             'membership_level'          => $membership_level,
+            'banned_until'              => $banned_until,
         ];
 
         // Define formats matching update_data order
@@ -314,7 +357,7 @@ class TTA_Ajax_Members {
             '%s','%s','%s','%s','%s',
             '%s','%s','%s','%d','%d',
             '%d','%d','%d','%d','%s',
-            '%s'
+            '%s','%s'
         ];
 
         // Run the update

--- a/includes/ajax/handlers/class-ajax-membership.php
+++ b/includes/ajax/handlers/class-ajax-membership.php
@@ -20,6 +20,9 @@ class TTA_Ajax_Membership {
             wp_send_json_error( [ 'message' => 'Invalid membership level.' ] );
         }
         $context = tta_get_current_user_context();
+        if ( $context['member'] && tta_user_is_banned( $context['wp_user_id'] ) ) {
+            wp_send_json_error( [ 'message' => __( 'You are currently banned from purchasing a membership.', 'tta' ) ] );
+        }
         $current_level = strtolower( $context['membership_level'] );
         if ( 'premium' === $current_level ) {
             wp_send_json_error( [ 'message' => __( 'You already have a Premium Membership.', 'tta' ) ] );

--- a/includes/class-db-setup.php
+++ b/includes/class-db-setup.php
@@ -134,6 +134,7 @@ class TTA_DB_Setup {
             opt_in_event_update_email       TINYINT(1) DEFAULT 0,
             opt_in_event_update_sms         TINYINT(1) DEFAULT 0,
             hide_event_attendance           TINYINT(1) DEFAULT 0,
+            banned_until                   DATETIME DEFAULT NULL,
             PRIMARY KEY  (id),
             KEY wpuserid_idx (wpuserid),
             KEY name_idx (last_name, first_name),

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -79,6 +79,22 @@ class TTA_Assets {
                 true
             );
 
+            // Image popup used for event images
+            wp_enqueue_style(
+                'tta-popup-css',
+                TTA_PLUGIN_URL . 'assets/css/frontend/profile-popup.css',
+                [],
+                TTA_PLUGIN_VERSION
+            );
+
+            wp_enqueue_script(
+                'tta-popup-js',
+                TTA_PLUGIN_URL . 'assets/js/frontend/profile-popup.js',
+                [ 'jquery' ],
+                TTA_PLUGIN_VERSION,
+                true
+            );
+
             wp_enqueue_script(
                 'tta-checkout-js',
                 TTA_PLUGIN_URL . 'assets/js/frontend/checkout-expiration-mask.js',

--- a/includes/frontend/class-tta-member-dashboard.php
+++ b/includes/frontend/class-tta-member-dashboard.php
@@ -126,6 +126,15 @@ class TTA_Member_Dashboard {
         <div class="tta-member-dashboard-wrap">
           <h2><?php echo esc_html( 'Welcome, ' . $member['first_name'] . '!' ); ?></h2>
           <p><?php echo esc_html( 'A Member since ' . date_i18n( 'F j, Y', strtotime( $member['joined_at'] ) ) ); ?></p>
+          <?php if ( ! empty( $member['banned_until'] ) && strtotime( $member['banned_until'] ) > time() ) : ?>
+            <div class="tta-banned-notice">
+              <?php
+              $until_ts = strtotime( $member['banned_until'] );
+              $label    = $until_ts > strtotime( '2099-01-01' ) ? __( 'indefinitely', 'tta' ) : date_i18n( 'F j, Y', $until_ts );
+              printf( esc_html__( 'You are banned from making purchases until %s.', 'tta' ), esc_html( $label ) );
+              ?>
+            </div>
+          <?php endif; ?>
 
           <div class="tta-member-dashboard">
             <div class="tta-dashboard-sidebar">

--- a/includes/frontend/templates/event-page-template.php
+++ b/includes/frontend/templates/event-page-template.php
@@ -803,8 +803,16 @@ echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESC
                   <div class="tta-gallery-item">
                     <?php
                       // use a medium-large size for good resolution;
-                      // WP will crop/scale as needed
-                      echo wp_get_attachment_image( $img_id, 'medium_large' );
+                      $full = wp_get_attachment_image_url( $img_id, 'large' );
+                      echo wp_get_attachment_image(
+                        $img_id,
+                        'medium_large',
+                        false,
+                        [
+                          'class'     => 'tta-popup-img',
+                          'data-full' => $full ? $full : wp_get_attachment_url( $img_id ),
+                        ]
+                      );
                     ?>
                   </div>
                 <?php endforeach; ?>

--- a/includes/frontend/views/tab-profile.php
+++ b/includes/frontend/views/tab-profile.php
@@ -24,10 +24,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- First Name -->
         <tr class="profile-row">
           <th>
-            <label for="first_name"><?php esc_html_e( 'First Name', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Enter your given first name as you’d like it displayed.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="first_name"><?php esc_html_e( 'First Name', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['first_name'] ); ?></span>
@@ -43,10 +43,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Last Name -->
         <tr class="profile-row">
           <th>
-            <label for="last_name"><?php esc_html_e( 'Last Name', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Enter your family/last name.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="last_name"><?php esc_html_e( 'Last Name', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['last_name'] ); ?></span>

--- a/includes/frontend/views/tab-profile.php
+++ b/includes/frontend/views/tab-profile.php
@@ -62,10 +62,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Email Address -->
         <tr class="profile-row">
           <th>
-            <label for="email"><?php esc_html_e( 'Email Address', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Primary email where we’ll send confirmations & updates.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="email"><?php esc_html_e( 'Email Address', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['email'] ); ?></span>
@@ -81,10 +81,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Verify Email Address (hidden until edit) -->
         <tr class="profile-row hide-until-edit">
           <th>
-            <label for="email_verify"><?php esc_html_e( 'Verify Email Address', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Re-enter your email to confirm there are no typos.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="email_verify"><?php esc_html_e( 'Verify Email Address', 'tta' ); ?></label>
           </th>
           <td>
             <input class="edit-input regular-text"
@@ -99,10 +99,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Phone Number -->
         <tr class="profile-row">
           <th>
-            <label for="phone"><?php esc_html_e( 'Phone Number', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Your number for SMS/text notifications.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="phone"><?php esc_html_e( 'Phone Number', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['phone'] ?: '—' ); ?></span>
@@ -117,10 +117,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Date of Birth -->
         <tr class="profile-row">
           <th>
-            <label for="dob"><?php esc_html_e( 'Date of Birth', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Used to verify age-restricted events.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="dob"><?php esc_html_e( 'Date of Birth', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['dob'] ?: '—' ); ?></span>
@@ -135,10 +135,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Facebook URL -->
         <tr class="profile-row">
           <th>
-            <label for="facebook"><?php esc_html_e( 'Facebook URL', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Link to your public Facebook profile.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="facebook"><?php esc_html_e( 'Facebook URL', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['facebook'] ?: '—' ); ?></span>
@@ -153,10 +153,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- LinkedIn URL -->
         <tr class="profile-row">
           <th>
-            <label for="linkedin"><?php esc_html_e( 'LinkedIn URL', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Link to your LinkedIn profile.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="linkedin"><?php esc_html_e( 'LinkedIn URL', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['linkedin'] ?: '—' ); ?></span>
@@ -171,10 +171,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Instagram URL -->
         <tr class="profile-row">
           <th>
-            <label for="instagram"><?php esc_html_e( 'Instagram URL', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Link to your Instagram account.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="instagram"><?php esc_html_e( 'Instagram URL', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['instagram'] ?: '—' ); ?></span>
@@ -189,10 +189,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Twitter URL -->
         <tr class="profile-row">
           <th>
-            <label for="twitter"><?php esc_html_e( 'Twitter URL', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Link to your Twitter handle.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="twitter"><?php esc_html_e( 'Twitter URL', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $member['twitter'] ?: '—' ); ?></span>
@@ -207,10 +207,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Street Address -->
         <tr class="profile-row">
           <th>
-            <label for="street_address"><?php esc_html_e( 'Street Address', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Your primary mailing address.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="street_address"><?php esc_html_e( 'Street Address', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $street_address ?: '—' ); ?></span>
@@ -225,10 +225,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Address Line 2 -->
         <tr class="profile-row">
           <th>
-            <label for="address_2"><?php esc_html_e( 'Address Line 2', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Apt, suite, unit, etc.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="address_2"><?php esc_html_e( 'Address Line 2', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $address_2 ?: '—' ); ?></span>
@@ -243,10 +243,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- City -->
         <tr class="profile-row">
           <th>
-            <label for="city"><?php esc_html_e( 'City', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'City or town.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="city"><?php esc_html_e( 'City', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $city ?: '—' ); ?></span>
@@ -261,10 +261,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- State -->
         <tr class="profile-row">
           <th>
-            <label for="state_fd"><?php esc_html_e( 'State', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Two-letter code (e.g. VA).', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="state_fd"><?php esc_html_e( 'State', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $state ?: '—' ); ?></span>
@@ -289,11 +289,11 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- ZIP Code -->
         <tr class="profile-row">
           <th>
-            <label for="zip"><?php esc_html_e( 'ZIP Code', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( '
 5-digit postal code.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="zip"><?php esc_html_e( 'ZIP Code', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value"><?php echo esc_html( $zip ?: '—' ); ?></span>
@@ -310,10 +310,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Biography -->
         <tr class="profile-row tta-wider-and-bigger-rows">
           <th>
-            <label for="biography"><?php esc_html_e( 'Biography', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Tell us about yourself—background, interests, etc.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="biography"><?php esc_html_e( 'Biography', 'tta' ); ?></label>
           </th>
           <td>
             <p class="view-value"><?php echo esc_html( $bio ?: '—' ); ?></p>
@@ -327,10 +327,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Interests -->
         <tr class="profile-row tta-wider-and-bigger-rows">
           <th>
-            <label for="interests_edit"><?php esc_html_e( 'Interests', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'List your hobbies or areas of interest.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label for="interests_edit"><?php esc_html_e( 'Interests', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value">
@@ -418,10 +418,10 @@ $hide_attendance = intval( $member['hide_event_attendance'] );
         <!-- Profile Image -->
         <tr class="profile-row tta-wider-and-bigger-rows">
           <th>
-            <label class="tta-special-vert-adjust"><?php esc_html_e( 'Profile Image', 'tta' ); ?></label>
             <span class="tta-tooltip-icon" data-tooltip="<?php esc_attr_e( 'Upload a picture for your public profile.', 'tta' ); ?>">
               <img src="<?php echo esc_url( TTA_PLUGIN_URL . 'assets/images/public/question.svg' ); ?>" alt="Help">
             </span>
+            <label class="tta-special-vert-adjust"><?php esc_html_e( 'Profile Image', 'tta' ); ?></label>
           </th>
           <td>
             <span class="view-value">

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -579,6 +579,36 @@ function tta_update_user_subscription_status( $wp_user_id, $status ) {
 }
 
 /**
+ * Get the timestamp until which a user is banned.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return string|null MySQL datetime string or null if not banned.
+ */
+function tta_get_user_banned_until( $wp_user_id ) {
+    $cache_key = 'banned_until_' . intval( $wp_user_id );
+    return TTA_Cache::remember( $cache_key, function() use ( $wp_user_id ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tta_members';
+        return $wpdb->get_var( $wpdb->prepare( "SELECT banned_until FROM {$table} WHERE wpuserid = %d", intval( $wp_user_id ) ) );
+    }, 300 );
+}
+
+/**
+ * Determine if a user is currently banned.
+ *
+ * @param int $wp_user_id WordPress user ID.
+ * @return bool
+ */
+function tta_user_is_banned( $wp_user_id ) {
+    $until = tta_get_user_banned_until( $wp_user_id );
+    if ( ! $until ) {
+        return false;
+    }
+    $timestamp = strtotime( $until );
+    return $timestamp && $timestamp > time();
+}
+
+/**
  * Retrieve the last four digits of a subscription's credit card.
  *
  * The data is cached for ten minutes to limit API calls.
@@ -1239,6 +1269,7 @@ function tta_get_current_user_context() {
         'membership_level' => 'free',
         'subscription_id'  => null,
         'subscription_status' => null,
+        'banned_until'      => null,
     ];
 
     if ( ! $context['is_logged_in'] ) {
@@ -1270,6 +1301,7 @@ function tta_get_current_user_context() {
         $context['membership_level']  = $member['membership_level'] ?? 'free';
         $context['subscription_id']   = $member['subscription_id'] ?? null;
         $context['subscription_status'] = $member['subscription_status'] ?? null;
+        $context['banned_until']      = $member['banned_until'] ?? null;
     }
 
     return $context;

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1714,6 +1714,14 @@ function tta_admin_preview_image( $attachment_id, array $size, array $attrs = []
         return '';
     }
 
+    $full = wp_get_attachment_image_url( $attachment_id, 'large' );
+    if ( ! $full ) {
+        $full = $url;
+    }
+
+    $attrs['class'] = isset( $attrs['class'] ) ? $attrs['class'] . ' tta-popup-img' : 'tta-popup-img';
+    $attrs['data-full'] = $full;
+
     $attr_str = '';
     foreach ( $attrs as $key => $val ) {
         $attr_str .= sprintf( ' %s="%s"', esc_attr( $key ), esc_attr( $val ) );

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -160,7 +160,8 @@ class HelpersTest extends TestCase {
     public function test_admin_preview_image_uses_fallback() {
         $html = tta_admin_preview_image(1, [50,50], ['class'=>'x']);
         $this->assertStringContainsString('file1.jpg', $html);
-        $this->assertStringContainsString('class="x"', $html);
+        $this->assertStringContainsString('class="x tta-popup-img"', $html);
+        $this->assertStringContainsString('data-full="file1.jpg"', $html);
     }
 
     public function test_get_member_upcoming_events_queries_tables() {

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -5,6 +5,7 @@ if (!defined('ARRAY_A')) { define('ARRAY_A', 'ARRAY_A'); }
 class DummyWpdbHelpers {
     public $prefix = 'wp_';
     public $var_calls = 0;
+    public $var_value = 'ute1';
     public $results_calls = 0;
     public $row_calls = 0;
     public $last_query = '';
@@ -13,7 +14,7 @@ class DummyWpdbHelpers {
 
     public function get_var($query) {
         $this->var_calls++;
-        return 'ute1';
+        return $this->var_value;
     }
 
     public function get_results($query, $output = ARRAY_A) {
@@ -162,6 +163,15 @@ class HelpersTest extends TestCase {
         $this->assertStringContainsString('file1.jpg', $html);
         $this->assertStringContainsString('class="x tta-popup-img"', $html);
         $this->assertStringContainsString('data-full="file1.jpg"', $html);
+    }
+
+    public function test_user_banned_helpers() {
+        global $wpdb;
+        $wpdb->var_calls = 0;
+        $wpdb->var_value = '2099-12-31 23:59:59';
+        $until = tta_get_user_banned_until(1);
+        $this->assertSame('2099-12-31 23:59:59', $until);
+        $this->assertTrue( tta_user_is_banned(1) );
     }
 
     public function test_get_member_upcoming_events_queries_tables() {

--- a/trying-to-adult-management-plugin.php
+++ b/trying-to-adult-management-plugin.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'TTA_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TTA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'TTA_PLUGIN_VERSION', '0.4.1' );
-define( 'TTA_DB_VERSION', '1.4.0' );
+define( 'TTA_DB_VERSION', '1.5.0' );
 define( 'TTA_BASIC_MEMBERSHIP_PRICE', 5.00 );
 define( 'TTA_PREMIUM_MEMBERSHIP_PRICE', 10.00 );
 define( 'TTA_BASIC_SUBSCRIPTION_NAME', 'Trying to Adult Basic Membership' );


### PR DESCRIPTION
## Summary
- display member summary, email, and notes in a table on Member History admin page
- document table layout for member history summary

## Testing
- `php ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685c69b1128483209913be747e63f801