### PR TITLE
Remove closing tags from class files

### DIFF
--- a/includes/classes/class-events.php
+++ b/includes/classes/class-events.php
@@ -2,4 +2,3 @@
 class TTA_Events {
     // TODO: Events CRUD methods
 }
-?>

--- a/includes/classes/class-members.php
+++ b/includes/classes/class-members.php
@@ -2,4 +2,3 @@
 class TTA_Members {
     // TODO: Members CRUD methods
 }
-?>

--- a/includes/classes/class-tickets.php
+++ b/includes/classes/class-tickets.php
@@ -2,4 +2,3 @@
 class TTA_Tickets {
     // TODO: Tickets CRUD methods
 }
-?>


### PR DESCRIPTION
## Summary
- clean up class files by dropping stray PHP closing tags
- ensure files end with a newline

## Testing
- `composer install`
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685ca37761f48320a926178463247fc3