### PR TITLE
Fix address parsing and state dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Object Caching](docs/ObjectCaching.md)
   - Plugin caches can now be cleared reliably even on hosts with persistent object caching.
 - [Input Sanitization Helpers](docs/InputSanitization.md)
+- [Address Helper Functions](docs/AddressHelpers.md)
 - [Event Page Context](docs/EventPage.md)
 - [Event Hosts & Volunteers](docs/EventPage.md#event-hosts-and-volunteers)
 - [Event Type Options](docs/EventTypes.md)

--- a/docs/AddressHelpers.md
+++ b/docs/AddressHelpers.md
@@ -1,0 +1,11 @@
+# Address Helper Functions
+
+The plugin stores both event and member addresses as a single string using dashes as delimiters:
+
+```
+Street – Address 2 – City – State – ZIP
+```
+
+Earlier sample data used a normal hyphen (`-`) while newer forms output an en dash (`–`). To ensure older rows continue to load, the new helper `tta_parse_address()` splits on either character and trims whitespace. It returns an associative array with keys `street`, `address2`, `city`, `state` and `zip`.
+
+Use this helper whenever an address needs to be broken into separate fields. `tta_format_address()` remains available for displaying a one line version on the front‑end.

--- a/includes/admin/views/members-create.php
+++ b/includes/admin/views/members-create.php
@@ -135,18 +135,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                     <td>
                         <select name="state" id="state">
                             <?php
-                            // You can customize this list if you already have a states schema.
-                            $states = [
-                                '' => '— Select State —',
-                                'AL' => 'Alabama',
-                                'AK' => 'Alaska',
-                                'AZ' => 'Arizona',
-                                // … (add all 50 states as needed) …
-                                'VA' => 'Virginia',
-                                'WV' => 'West Virginia',
-                                'WI' => 'Wisconsin',
-                                'WY' => 'Wyoming',
-                            ];
+                            $states = [ '' => '— Select State —' ] + tta_get_us_states();
                             foreach ( $states as $abbr => $label ) {
                                 printf(
                                     '<option value="%s">%s</option>',

--- a/includes/admin/views/members-edit.php
+++ b/includes/admin/views/members-edit.php
@@ -19,19 +19,19 @@ $wp_user_id   = intval( $member['wpuserid'] );
 $profileimgid = $member['profileimgid'];
 $hide_attendance = intval( $member['hide_event_attendance'] );
 
-// Parse address into components using “ – ” (en-dash) as delimiter
+// Parse address components
 $street_address = '';
 $address_2      = '';
 $city           = '';
 $state          = '';
 $zip            = '';
 if ( ! empty( $member['address'] ) ) {
-    $parts = array_map( 'trim', explode( ' – ', $member['address'] ) );
-    $street_address = $parts[0] ?? '';
-    $address_2      = $parts[1] ?? '';
-    $city           = $parts[2] ?? '';
-    $state          = $parts[3] ?? '';
-    $zip            = $parts[4] ?? '';
+    $addr            = tta_parse_address( $member['address'] );
+    $street_address  = $addr['street'];
+    $address_2       = $addr['address2'];
+    $city            = $addr['city'];
+    $state           = $addr['state'];
+    $zip             = $addr['zip'];
 }
 
 // Ensure media uploader can work:

--- a/includes/admin/views/venues-create.php
+++ b/includes/admin/views/venues-create.php
@@ -19,6 +19,8 @@ if ( isset( $_GET['venue_id'] ) ) {
     }
 }
 
+$addr_parts = tta_parse_address( $venue['address'] ?? '' );
+
 if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_action', 'tta_venue_save_nonce' ) ) {
     $address = implode( ' - ', array_filter( [
         tta_sanitize_text_field( $_POST['street_address'] ),
@@ -119,7 +121,7 @@ if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_a
                 <label for="street_address">Street Address</label>
             </th>
             <td>
-                <input type="text" name="street_address" id="street_address" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[0] ?? '' ); ?>">
+                <input type="text" name="street_address" id="street_address" class="regular-text" value="<?php echo esc_attr( $addr_parts['street'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -130,7 +132,7 @@ if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_a
                 <label for="address_2">Address 2</label>
             </th>
             <td>
-                <input type="text" name="address_2" id="address_2" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[1] ?? '' ); ?>">
+                <input type="text" name="address_2" id="address_2" class="regular-text" value="<?php echo esc_attr( $addr_parts['address2'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -141,7 +143,7 @@ if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_a
                 <label for="city">City</label>
             </th>
             <td>
-                <input type="text" name="city" id="city" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[2] ?? '' ); ?>">
+                <input type="text" name="city" id="city" class="regular-text" value="<?php echo esc_attr( $addr_parts['city'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -152,7 +154,7 @@ if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_a
                 <label for="state">State</label>
             </th>
             <td>
-                <input type="text" name="state" id="state" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[3] ?? '' ); ?>">
+                <input type="text" name="state" id="state" class="regular-text" value="<?php echo esc_attr( $addr_parts['state'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -163,7 +165,7 @@ if ( isset( $_POST['tta_venue_save'] ) && check_admin_referer( 'tta_venue_save_a
                 <label for="zip">ZIP</label>
             </th>
             <td>
-                <input type="text" name="zip" id="zip" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[4] ?? '' ); ?>">
+                <input type="text" name="zip" id="zip" class="regular-text" value="<?php echo esc_attr( $addr_parts['zip'] ); ?>">
             </td>
         </tr>
         </tbody>

--- a/includes/admin/views/venues-edit.php
+++ b/includes/admin/views/venues-edit.php
@@ -18,6 +18,8 @@ if ( isset( $_GET['venue_id'] ) ) {
         $editing = true;
     }
 }
+
+$addr_parts = tta_parse_address( $venue['address'] ?? '' );
 ?>
 <form method="post" id="tta-venue-edit-form">
     <?php wp_nonce_field( 'tta_venue_save_action', 'tta_venue_save_nonce' ); ?>
@@ -89,7 +91,7 @@ if ( isset( $_GET['venue_id'] ) ) {
                 <label for="street_address">Street Address</label>
             </th>
             <td>
-                <input type="text" name="street_address" id="street_address" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[0] ?? '' ); ?>">
+                <input type="text" name="street_address" id="street_address" class="regular-text" value="<?php echo esc_attr( $addr_parts['street'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -100,7 +102,7 @@ if ( isset( $_GET['venue_id'] ) ) {
                 <label for="address_2">Address 2</label>
             </th>
             <td>
-                <input type="text" name="address_2" id="address_2" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[1] ?? '' ); ?>">
+                <input type="text" name="address_2" id="address_2" class="regular-text" value="<?php echo esc_attr( $addr_parts['address2'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -111,7 +113,7 @@ if ( isset( $_GET['venue_id'] ) ) {
                 <label for="city">City</label>
             </th>
             <td>
-                <input type="text" name="city" id="city" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[2] ?? '' ); ?>">
+                <input type="text" name="city" id="city" class="regular-text" value="<?php echo esc_attr( $addr_parts['city'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -122,7 +124,7 @@ if ( isset( $_GET['venue_id'] ) ) {
                 <label for="state">State</label>
             </th>
             <td>
-                <input type="text" name="state" id="state" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[3] ?? '' ); ?>">
+                <input type="text" name="state" id="state" class="regular-text" value="<?php echo esc_attr( $addr_parts['state'] ); ?>">
             </td>
         </tr>
         <tr>
@@ -133,7 +135,7 @@ if ( isset( $_GET['venue_id'] ) ) {
                 <label for="zip">ZIP</label>
             </th>
             <td>
-                <input type="text" name="zip" id="zip" class="regular-text" value="<?php echo esc_attr( explode( ' - ', $venue['address'] ?? '' )[4] ?? '' ); ?>">
+                <input type="text" name="zip" id="zip" class="regular-text" value="<?php echo esc_attr( $addr_parts['zip'] ); ?>">
             </td>
         </tr>
         </tbody>

--- a/includes/frontend/class-tta-member-dashboard.php
+++ b/includes/frontend/class-tta-member-dashboard.php
@@ -113,12 +113,12 @@ class TTA_Member_Dashboard {
         $state          = '';
         $zip            = '';
         if ( ! empty( $member['address'] ) ) {
-            $parts          = array_map( 'trim', explode( ' – ', $member['address'] ) );
-            $street_address = $parts[0] ?? '';
-            $address_2      = $parts[1] ?? '';
-            $city           = $parts[2] ?? '';
-            $state          = $parts[3] ?? '';
-            $zip            = $parts[4] ?? '';
+            $addr            = tta_parse_address( $member['address'] );
+            $street_address  = $addr['street'];
+            $address_2       = $addr['address2'];
+            $city            = $addr['city'];
+            $state           = $addr['state'];
+            $zip             = $addr['zip'];
         }
 
         ob_start();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -755,6 +755,27 @@ function tta_format_address( $raw ) {
 }
 
 /**
+ * Parse a raw address string into components.
+ *
+ * The database stores addresses separated by either a hyphen or an en dash.
+ * This helper splits on both characters so older rows continue to load
+ * correctly.
+ *
+ * @param string $raw Raw address string.
+ * @return array{street:string,address2:string,city:string,state:string,zip:string}
+ */
+function tta_parse_address( $raw ) {
+    $parts = preg_split( '/\s*[-–]\s*/u', $raw );
+    return [
+        'street'   => trim( $parts[0] ?? '' ),
+        'address2' => trim( $parts[1] ?? '' ),
+        'city'     => trim( $parts[2] ?? '' ),
+        'state'    => trim( $parts[3] ?? '' ),
+        'zip'      => trim( $parts[4] ?? '' ),
+    ];
+}
+
+/**
  * Retrieve upcoming events purchased by a user.
  *
  * @param int $wp_user_id WordPress user ID.


### PR DESCRIPTION
## Summary
- add new `tta_parse_address()` helper for reliable dash parsing
- apply new helper to member, venue and dashboard screens
- use full state list when creating members
- document address helpers

## Testing
- `composer install`
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685dc46f1eb883209880e7967148453c