### PR TITLE
Add sandbox test automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If these constants are not defined, checkout will fail and an admin notice will 
 - [Object Caching](docs/ObjectCaching.md)
   - Plugin caches can now be cleared reliably even on hosts with persistent object caching.
 - [Input Sanitization Helpers](docs/InputSanitization.md)
+- [Authorize.Net Error Codes](docs/AuthorizeNetErrors.md)
 - [Address Helper Functions](docs/AddressHelpers.md)
 - [Event Page Context](docs/EventPage.md)
 - [Event Hosts & Volunteers](docs/EventPage.md#event-hosts-and-volunteers)

--- a/assets/js/backend/admin.js
+++ b/assets/js/backend/admin.js
@@ -1191,4 +1191,26 @@ $(document).on('click', '.tta-remove-waitlist-entry', function(e){
 
 
 
+  // Authorize.Net test suite button
+  $(document).on('click', '#tta-authnet-test-button', function(e){
+    e.preventDefault();
+    var $btn  = $(this);
+    var $spin = $btn.siblings('.tta-admin-progress-spinner-svg').css({display:'inline-block',opacity:0}).fadeTo(200,1);
+    var $resp = $('#tta-authnet-test-wrapper .tta-admin-progress-response-p').removeClass('updated error').text('');
+    $.post(TTA_Ajax.ajax_url, {
+      action: 'tta_run_authnet_tests',
+      nonce: TTA_Ajax.authnet_test_nonce
+    }, function(res){
+      $spin.fadeOut(200);
+      if (res.success) {
+        $resp.addClass('updated').text(res.data.message);
+      } else {
+        $resp.addClass('error').text(res.data.message || 'Error');
+      }
+    }, 'json').fail(function(){
+      $spin.fadeOut(200);
+      $resp.addClass('error').text('Request failed.');
+    });
+  });
+
 });/* end jQuery(function($) ) */

--- a/docs/AuthorizeNetErrors.md
+++ b/docs/AuthorizeNetErrors.md
@@ -1,0 +1,13 @@
+# Authorize.Net Error Codes
+
+The plugin surfaces Authorize.Net error codes during checkout and refunds. When a common error is detected, an additional explanation is appended to the message.
+
+| Code   | Meaning | Additional Notes |
+| ------ | ------- | ---------------- |
+| `E00001` | An unexpected error occurred. | Retry the request. |
+| `E00002` | Login invalid or account inactive. | Check the API Login ID and Transaction Key. |
+| `E00003` | The referenced record was not found. | Likely an invalid transaction or customer ID. |
+| `E00007` | User authentication failed. | Verify your sandbox credentials. |
+| `E00027` | The transaction was unsuccessful. | Typically declined by the processor or card issuer. |
+
+Unknown codes continue to display as-is from Authorize.Net.

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -54,7 +54,7 @@ This document summarizes the current logic around the cart and checkout process 
 - Pricing logic branches on membership level when adding items to the cart.
 - Each member may purchase a maximum of two tickets per event. Quantities in the cart plus past purchases are checked during the `tta_add_to_cart` AJAX request.
 - Checkout can branch if inventory changes mid-process, redirecting back to the cart with a notice.
-- Payment failure stops checkout and displays the returned error.
+- Payment failure stops checkout and displays the returned error. The plugin now surfaces Authorize.Net error codes and descriptions (for example `11: A duplicate transaction has been submitted`).
 - Successful completion empties the cart and fires hooks for additional actions (e.g., ticket emails).
 
 This flow will evolve as more features are added. Additional documentation for creating events, editing events, managing members, and other future functionality will live alongside this document in the `docs/` directory.

--- a/docs/CartFlow.md
+++ b/docs/CartFlow.md
@@ -54,7 +54,7 @@ This document summarizes the current logic around the cart and checkout process 
 - Pricing logic branches on membership level when adding items to the cart.
 - Each member may purchase a maximum of two tickets per event. Quantities in the cart plus past purchases are checked during the `tta_add_to_cart` AJAX request.
 - Checkout can branch if inventory changes mid-process, redirecting back to the cart with a notice.
-- Payment failure stops checkout and displays the returned error. The plugin now surfaces Authorize.Net error codes and descriptions (for example `11: A duplicate transaction has been submitted`).
+ - Payment failure stops checkout and displays the returned error. The plugin now surfaces Authorize.Net error codes and descriptions (for example `11: A duplicate transaction has been submitted`). If the code is recognized, an extra sentence explains what it means.
 - Successful completion empties the cart and fires hooks for additional actions (e.g., ticket emails).
 
 This flow will evolve as more features are added. Additional documentation for creating events, editing events, managing members, and other future functionality will live alongside this document in the `docs/` directory.

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -5,3 +5,5 @@ The **TTA Settings** page includes a small debugging console below the cache cle
 The log output is displayed in a scrollable `<pre>` block. A **Clear Log** button removes all entries. Messages are preserved across requests until cleared and include a timestamp along with the error type and location.
 
 This feature is intended for development only. Before deploying to production, consider disabling or removing the logger to avoid collecting sensitive information.
+
+The settings page also provides an **Authorize.net testing** button. Clicking it triggers a series of automated purchases through the plugin's AJAX endpoints using your sandbox credentials. Each scenario (single ticket, multiple tickets, membership only, and membership plus tickets) runs with short delays to avoid API throttling. Progress and results for every step are written to the debug log.

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -98,3 +98,7 @@ Buttons labelled with tokens (e.g. `{event_name}`) insert placeholders into the 
 ```
 
 Use the **Line Break** button to insert a newline. Email previews render these breaks as HTML `<br>` tags so the saved text remains plain.
+
+## Email Delivery
+
+All outgoing messages are dispatched by the `TTA_Email_Handler` class. The handler is loaded on plugin init and is responsible for reading the templates saved on the **Email & SMS** page. After a transaction is recorded, `send_purchase_emails()` groups the purchased items by event and emails the **Successful Event Purchase** template. The purchasing member and every attendee receive their own copy, with one message sent for each event in the cart.

--- a/docs/EmailSMS.md
+++ b/docs/EmailSMS.md
@@ -25,6 +25,8 @@ Each template stores:
 - **Email Body** – text shown above the automatically generated event details
 - **SMS Text** – short message sent via SMS
 
+All fields are sanitized with the helper functions from `InputSanitization.md`. This strips WordPress slashes so apostrophes display correctly in the admin preview and in the actual emails.
+
 Default values are provided on initial install:
 
 - **Purchase Email Subject**: "Thanks for Registering!"

--- a/docs/InputSanitization.md
+++ b/docs/InputSanitization.md
@@ -14,3 +14,5 @@ $url   = tta_esc_url_raw( $_POST['facebook'] );
 All helpers use `wp_unslash()` recursively so both strings and arrays are handled correctly. Existing logic that previously called `sanitize_text_field()` or related functions has been updated to use these wrappers.
 
 Using these functions prevents escaped apostrophes from appearing on the front‑end and ensures data is safely stored without stray slashes.
+
+The Email & SMS template editor leverages these helpers when saving changes. Administrators can include apostrophes or quotes in message text without backslashes appearing in the WordPress admin or outgoing notifications.

--- a/includes/admin/class-comms-admin.php
+++ b/includes/admin/class-comms-admin.php
@@ -132,9 +132,9 @@ class TTA_Comms_Admin {
 
         if ( isset( $_POST['template_key'] ) && isset( $_POST['tta_comms_save_nonce'] ) && check_admin_referer( 'tta_comms_save_action', 'tta_comms_save_nonce' ) ) {
             $key       = sanitize_key( $_POST['template_key'] );
-            $templates[ $key ]['email_subject'] = sanitize_text_field( $_POST['email_subject'] ?? $templates[$key]['email_subject'] );
-            $templates[ $key ]['email_body']    = sanitize_textarea_field( $_POST['email_body'] ?? $templates[$key]['email_body'] );
-            $templates[ $key ]['sms_text']      = sanitize_textarea_field( $_POST['sms_text'] ?? $templates[$key]['sms_text'] );
+            $templates[ $key ]['email_subject'] = tta_sanitize_text_field( $_POST['email_subject'] ?? $templates[ $key ]['email_subject'] );
+            $templates[ $key ]['email_body']    = tta_sanitize_textarea_field( $_POST['email_body'] ?? $templates[ $key ]['email_body'] );
+            $templates[ $key ]['sms_text']      = tta_sanitize_textarea_field( $_POST['sms_text'] ?? $templates[ $key ]['sms_text'] );
             update_option( 'tta_comms_templates', $templates, false );
             echo '<div class="updated"><p>'.esc_html__( 'Template saved.', 'tta' ).'</p></div>';
         }

--- a/includes/admin/class-settings-admin.php
+++ b/includes/admin/class-settings-admin.php
@@ -62,6 +62,14 @@ class TTA_Settings_Admin {
         echo '<p><input type="submit" name="tta_delete_sample_data" class="button button-secondary" value="Delete Sample Data"></p>';
         echo '</form>';
 
+        echo '<div id="tta-authnet-test-wrapper">';
+        echo '<p>';
+        echo '<button id="tta-authnet-test-button" class="button button-secondary">Authorize.net testing</button>';
+        echo '<span class="tta-admin-progress-spinner-div"><img class="tta-admin-progress-spinner-svg" src="' . esc_url( TTA_PLUGIN_URL . 'assets/images/admin/loading.svg' ) . '" alt="" style="display:none;"></span>';
+        echo '</p>';
+        echo '<p class="tta-admin-progress-response-p"></p>';
+        echo '</div>';
+
         if ( isset( $_POST['tta_clear_log'] ) && check_admin_referer( 'tta_clear_log_action', 'tta_clear_log_nonce' ) ) {
             TTA_Debug_Logger::clear();
             echo '<div class="updated"><p>Debug log cleared.</p></div>';

--- a/includes/ajax/class-ajax-handler.php
+++ b/includes/ajax/class-ajax-handler.php
@@ -15,6 +15,7 @@ require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-comms.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-attendance.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-calendar.php';
 require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-venues.php';
+require_once TTA_PLUGIN_DIR . 'includes/ajax/handlers/class-ajax-authnet-test.php';
 
 
 // Initialize them
@@ -29,3 +30,4 @@ TTA_Ajax_Comms::init();
 TTA_Ajax_Attendance::init();
 TTA_Ajax_Calendar::init();
 TTA_Ajax_Venues::init();
+TTA_Ajax_Authnet_Test::init();

--- a/includes/ajax/handlers/class-ajax-authnet-test.php
+++ b/includes/ajax/handlers/class-ajax-authnet-test.php
@@ -1,0 +1,125 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class TTA_Ajax_Authnet_Test {
+    public static function init() {
+        add_action( 'wp_ajax_tta_run_authnet_tests', [ __CLASS__, 'run_tests' ] );
+    }
+
+    protected static function request( $body, $cookies ) {
+        $resp = wp_remote_post( admin_url( 'admin-ajax.php' ), [
+            'body'    => $body,
+            'timeout' => 20,
+            'cookies' => $cookies,
+        ] );
+        if ( is_wp_error( $resp ) ) {
+            return [ 'error' => $resp->get_error_message() ];
+        }
+        $data = json_decode( wp_remote_retrieve_body( $resp ), true );
+        if ( null === $data ) {
+            return [ 'error' => 'Invalid JSON response' ];
+        }
+        return $data;
+    }
+
+    public static function run_tests() {
+        check_ajax_referer( 'tta_authnet_test_action', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Permission denied.' ] );
+        }
+
+        if ( ! session_id() ) {
+            session_start();
+        }
+        $cookies = [ new WP_Http_Cookie( [
+            'name'  => session_name(),
+            'value' => session_id(),
+        ] ) ];
+
+        TTA_Debug_Logger::log( 'Authorize.Net test suite started.' );
+
+        $scenarios = [
+            'single_ticket'           => [ 'tickets' => 1, 'membership' => false ],
+            'multiple_tickets'       => [ 'tickets' => 2, 'membership' => false ],
+            'membership_only'        => [ 'tickets' => 0, 'membership' => true ],
+            'membership_plus_ticket' => [ 'tickets' => 1, 'membership' => true ],
+        ];
+
+        foreach ( $scenarios as $label => $config ) {
+            self::run_scenario( $label, $config, $cookies );
+            sleep( 2 );
+        }
+
+        TTA_Debug_Logger::log( 'Authorize.Net test suite finished.' );
+        wp_send_json_success( [ 'message' => 'Test run complete. Check debug log.' ] );
+    }
+
+    protected static function run_scenario( $label, $config, $cookies ) {
+        TTA_Debug_Logger::log( 'Scenario: ' . $label );
+
+        $event = tta_get_next_event();
+        if ( ! $event ) {
+            TTA_Debug_Logger::log( 'No upcoming events found.' );
+            return;
+        }
+
+        global $wpdb;
+        $ute  = $wpdb->get_var( $wpdb->prepare( "SELECT ute_id FROM {$wpdb->prefix}tta_events WHERE id = %d", $event['id'] ) );
+        $ticket_id = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$wpdb->prefix}tta_tickets WHERE event_ute_id = %s LIMIT 1", $ute ) );
+        if ( ! $ticket_id ) {
+            TTA_Debug_Logger::log( 'No ticket found for event.' );
+            return;
+        }
+
+        if ( $config['tickets'] > 0 ) {
+            $res = self::request( [
+                'action' => 'tta_add_to_cart',
+                'nonce'  => wp_create_nonce( 'tta_frontend_nonce' ),
+                'items'  => wp_json_encode( [ [ 'ticket_id' => $ticket_id, 'quantity' => $config['tickets'] ] ] ),
+            ], $cookies );
+            if ( empty( $res['success'] ) ) {
+                $msg = $res['data']['message'] ?? ( $res['error'] ?? 'Add to cart error' );
+                TTA_Debug_Logger::log( 'Add to cart failed: ' . $msg );
+                return;
+            }
+            TTA_Debug_Logger::log( 'Added ' . $config['tickets'] . ' tickets to cart.' );
+        }
+
+        if ( $config['membership'] ) {
+            $res = self::request( [
+                'action' => 'tta_add_membership',
+                'nonce'  => wp_create_nonce( 'tta_frontend_nonce' ),
+                'level'  => 'basic',
+            ], $cookies );
+            if ( empty( $res['success'] ) ) {
+                $msg = $res['data']['message'] ?? ( $res['error'] ?? 'Membership error' );
+                TTA_Debug_Logger::log( 'Add membership failed: ' . $msg );
+                return;
+            }
+            TTA_Debug_Logger::log( 'Added membership to cart.' );
+        }
+
+        $member = tta_get_sample_member();
+        $res = self::request( [
+            'action'              => 'tta_do_checkout',
+            'nonce'               => wp_create_nonce( 'tta_checkout_action' ),
+            'card_number'         => '4111111111111111',
+            'card_exp'            => '12/39',
+            'card_cvc'            => '123',
+            'billing_first_name'  => $member['first_name'],
+            'billing_last_name'   => $member['last_name'],
+            'billing_street'      => '123 Main St',
+            'billing_city'        => 'Anytown',
+            'billing_state'       => 'VA',
+            'billing_zip'         => '12345',
+        ], $cookies );
+        if ( empty( $res['success'] ) ) {
+            $msg = $res['data']['message'] ?? ( $res['error'] ?? 'Checkout error' );
+            TTA_Debug_Logger::log( 'Checkout failed: ' . $msg );
+            return;
+        }
+        TTA_Debug_Logger::log( 'Checkout success.' );
+    }
+}
+
+TTA_Ajax_Authnet_Test::init();

--- a/includes/ajax/handlers/class-ajax-comms.php
+++ b/includes/ajax/handlers/class-ajax-comms.php
@@ -24,9 +24,9 @@ class TTA_Ajax_Comms {
             wp_send_json_error( [ 'message' => 'Template not found.' ] );
         }
 
-        $templates[ $key ]['email_subject'] = sanitize_text_field( $_POST['email_subject'] ?? $templates[$key]['email_subject'] );
-        $templates[ $key ]['email_body']    = sanitize_textarea_field( $_POST['email_body'] ?? $templates[$key]['email_body'] );
-        $templates[ $key ]['sms_text']      = sanitize_textarea_field( $_POST['sms_text'] ?? $templates[$key]['sms_text'] );
+        $templates[ $key ]['email_subject'] = tta_sanitize_text_field( $_POST['email_subject'] ?? $templates[ $key ]['email_subject'] );
+        $templates[ $key ]['email_body']    = tta_sanitize_textarea_field( $_POST['email_body'] ?? $templates[ $key ]['email_body'] );
+        $templates[ $key ]['sms_text']      = tta_sanitize_textarea_field( $_POST['sms_text'] ?? $templates[ $key ]['sms_text'] );
 
         update_option( 'tta_comms_templates', $templates, false );
 

--- a/includes/api/class-authorizenet-api.php
+++ b/includes/api/class-authorizenet-api.php
@@ -46,7 +46,27 @@ class TTA_AuthorizeNet_API {
         if ( '' === $text ) {
             return $default;
         }
-        return $code ? sprintf( '%s: %s', $code, $text ) : $text;
+        $message = $code ? sprintf( '%s: %s', $code, $text ) : $text;
+        $extra   = $this->error_help( $code );
+        return $extra ? $message . ' (' . $extra . ')' : $message;
+    }
+
+    /**
+     * Provide a human friendly explanation for common API error codes.
+     *
+     * @param string $code Error code returned by the API.
+     * @return string
+     */
+    protected function error_help( $code ) {
+        $map = [
+            'E00001' => 'An unexpected error occurred. Please try again.',
+            'E00002' => 'The login is invalid or the API account is inactive.',
+            'E00003' => 'The referenced record was not found.',
+            'E00007' => 'Credentials are invalid. Check your API Login ID and Transaction Key.',
+            'E00027' => 'The transaction was declined by the processor or card issuer.',
+        ];
+
+        return $map[ $code ] ?? '';
     }
 
     public function __construct( $login_id = null, $transaction_key = null, $sandbox = null ) {

--- a/includes/api/class-authorizenet-api.php
+++ b/includes/api/class-authorizenet-api.php
@@ -12,6 +12,43 @@ class TTA_AuthorizeNet_API {
     protected $transaction_key;
     protected $environment;
 
+    /**
+     * Format an error message from an API response.
+     *
+     * @param mixed $response  Response object returned by the Authorize.Net SDK.
+     * @param mixed $tresponse Optional transaction response.
+     * @param string $default  Fallback message.
+     * @return string
+     */
+    protected function format_error( $response, $tresponse = null, $default = 'Transaction failed' ) {
+        $code = '';
+        $text = '';
+
+        if ( $tresponse && method_exists( $tresponse, 'getErrors' ) && $tresponse->getErrors() ) {
+            $err  = $tresponse->getErrors()[0];
+            $code = method_exists( $err, 'getErrorCode' ) ? $err->getErrorCode() : '';
+            $text = method_exists( $err, 'getErrorText' ) ? $err->getErrorText() : '';
+        }
+
+        if ( '' === $text && $tresponse && method_exists( $tresponse, 'getMessages' ) && $tresponse->getMessages() ) {
+            $msg  = $tresponse->getMessages()[0];
+            $code = method_exists( $msg, 'getCode' ) ? $msg->getCode() : '';
+            $text = method_exists( $msg, 'getDescription' ) ? $msg->getDescription() : '';
+        }
+
+        if ( '' === $text && $response && method_exists( $response, 'getMessages' ) && $response->getMessages()->getMessage() ) {
+            $m    = $response->getMessages()->getMessage()[0];
+            $code = method_exists( $m, 'getCode' ) ? $m->getCode() : '';
+            $text = method_exists( $m, 'getText' ) ? $m->getText() : '';
+        }
+
+        $text = trim( $text );
+        if ( '' === $text ) {
+            return $default;
+        }
+        return $code ? sprintf( '%s: %s', $code, $text ) : $text;
+    }
+
     public function __construct( $login_id = null, $transaction_key = null, $sandbox = null ) {
         $this->login_id        = $login_id        ?: ( defined( 'TTA_AUTHNET_LOGIN_ID' ) ? TTA_AUTHNET_LOGIN_ID : '' );
         $this->transaction_key = $transaction_key ?: ( defined( 'TTA_AUTHNET_TRANSACTION_KEY' ) ? TTA_AUTHNET_TRANSACTION_KEY : '' );
@@ -75,20 +112,20 @@ class TTA_AuthorizeNet_API {
             $tresponse = $response->getTransactionResponse();
             if ( $tresponse && $tresponse->getResponseCode() === '1' ) {
                 return [
-                    'success'         => true,
-                    'transaction_id'  => $tresponse->getTransId(),
+                    'success'        => true,
+                    'transaction_id' => $tresponse->getTransId(),
                 ];
             }
-            $err = $tresponse && $tresponse->getErrors()
-                ? $tresponse->getErrors()[0]->getErrorText()
-                : 'Transaction failed';
-            return [ 'success' => false, 'error' => $err ];
+            return [
+                'success' => false,
+                'error'   => $this->format_error( $response, $tresponse, 'Transaction failed' ),
+            ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -133,16 +170,16 @@ class TTA_AuthorizeNet_API {
             if ( $tresponse && $tresponse->getResponseCode() === '1' ) {
                 return [ 'success' => true, 'transaction_id' => $tresponse->getTransId() ];
             }
-            $err = $tresponse && $tresponse->getErrors()
-                ? $tresponse->getErrors()[0]->getErrorText()
-                : 'Refund failed';
-            return [ 'success' => false, 'error' => $err ];
+            return [
+                'success' => false,
+                'error'   => $this->format_error( $response, $tresponse, 'Refund failed' ),
+            ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -214,10 +251,10 @@ class TTA_AuthorizeNet_API {
             return [ 'success' => true, 'subscription_id' => $id ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -246,10 +283,10 @@ class TTA_AuthorizeNet_API {
             return [ 'success' => true ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -305,10 +342,10 @@ class TTA_AuthorizeNet_API {
             return $data;
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -363,10 +400,10 @@ class TTA_AuthorizeNet_API {
             return [ 'success' => true ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 
     /**
@@ -400,9 +437,9 @@ class TTA_AuthorizeNet_API {
             return [ 'success' => true ];
         }
 
-        $err = $response && $response->getMessages()->getMessage()
-            ? $response->getMessages()->getMessage()[0]->getText()
-            : 'API error';
-        return [ 'success' => false, 'error' => $err ];
+        return [
+            'success' => false,
+            'error'   => $this->format_error( $response, null, 'API error' ),
+        ];
     }
 }

--- a/includes/cart/class-cart.php
+++ b/includes/cart/class-cart.php
@@ -500,9 +500,11 @@ class TTA_Cart {
 
     $discount_total = max( 0, $total_before - $total_after );
 
-    // Log transaction details
+    // Log transaction details and send notifications
     if ( $transaction_id ) {
-      TTA_Transaction_Logger::log( $transaction_id, $amount, $items, implode( ',', $discount_codes ), $discount_total, get_current_user_id(), $card_last4 );
+      $user_id = get_current_user_id();
+      TTA_Transaction_Logger::log( $transaction_id, $amount, $items, implode( ',', $discount_codes ), $discount_total, $user_id, $card_last4 );
+      TTA_Email_Handler::get_instance()->send_purchase_emails( $items, $user_id );
     }
 
     $this->empty_cart();

--- a/includes/classes/class-tta-assets.php
+++ b/includes/classes/class-tta-assets.php
@@ -122,6 +122,7 @@ class TTA_Assets {
                     'save_comm_nonce'     => wp_create_nonce( 'tta_comms_save_action' ),
                     'membership_admin_nonce' => wp_create_nonce( 'tta_membership_admin_action' ),
                     'attendee_admin_nonce' => wp_create_nonce( 'tta_attendee_admin_action' ),
+                    'authnet_test_nonce'   => wp_create_nonce( 'tta_authnet_test_action' ),
                     'sample_event'        => ( function() {
                         $e = tta_get_next_event();
                         if ( ! $e ) {

--- a/includes/email/class-email-handler.php
+++ b/includes/email/class-email-handler.php
@@ -1,8 +1,125 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Handles outbound email notifications.
+ */
 class TTA_Email_Handler {
-    public static function get_instance() { static $inst; return $inst ?: $inst = new self(); }
+    /** @var self */
+    protected static $instance;
+
+    /**
+     * Singleton accessor.
+     *
+     * @return self
+     */
+    public static function get_instance() {
+        return self::$instance ?: ( self::$instance = new self() );
+    }
+
+    /** Initialize hooks. */
     private function __construct() {
-        // TODO: Email notification hooks
+        // Placeholder for future scheduling hooks.
+    }
+
+    /**
+     * Send purchase confirmation emails for each event in the cart.
+     *
+     * @param array $items   Items array from TTA_Cart::get_items_with_discounts().
+     * @param int   $user_id WordPress user ID who completed checkout.
+     */
+    public function send_purchase_emails( array $items, $user_id ) {
+        $templates = tta_get_comm_templates();
+        if ( empty( $templates['purchase'] ) ) {
+            return;
+        }
+        $tpl = $templates['purchase'];
+
+        $context = tta_get_current_user_context();
+        if ( $context['wp_user_id'] !== intval( $user_id ) ) {
+            $user = get_user_by( 'ID', $user_id );
+            if ( $user ) {
+                $context['wp_user_id'] = $user_id;
+                $context['user_email'] = sanitize_email( $user->user_email );
+                $context['first_name'] = sanitize_text_field( $user->first_name );
+                $context['last_name']  = sanitize_text_field( $user->last_name );
+            }
+        }
+
+        $by_event = [];
+        foreach ( $items as $it ) {
+            $by_event[ $it['event_ute_id'] ][] = $it;
+        }
+
+        foreach ( $by_event as $ute_id => $ev_items ) {
+            $event = tta_get_event_for_email( $ute_id );
+            if ( empty( $event ) ) {
+                continue;
+            }
+            $attendees = [];
+            foreach ( $ev_items as $it ) {
+                foreach ( (array) ( $it['attendees'] ?? [] ) as $att ) {
+                    $attendees[] = $att;
+                }
+            }
+
+            $tokens = $this->build_tokens( $event, $context, $attendees );
+            $subject = strtr( $tpl['email_subject'], $tokens );
+            $body    = nl2br( strtr( $tpl['email_body'], $tokens ) );
+
+            $recipients = array_unique( array_merge( [ $context['user_email'] ], array_column( $attendees, 'email' ) ) );
+            $headers    = [ 'Content-Type: text/html; charset=UTF-8' ];
+            foreach ( $recipients as $to ) {
+                $to = sanitize_email( $to );
+                if ( $to ) {
+                    wp_mail( $to, $subject, $body, $headers );
+                }
+            }
+        }
+    }
+
+    /**
+     * Build a token replacement map for an event email.
+     *
+     * @param array $event     Event details from tta_get_event_for_email().
+     * @param array $member    Current user context from tta_get_current_user_context().
+     * @param array $attendees List of attendee arrays.
+     * @return array
+     */
+    protected function build_tokens( array $event, array $member, array $attendees ) {
+        $tokens = [
+            '{event_name}'           => $event['name'] ?? '',
+            '{event_address}'        => $event['address'] ?? '',
+            '{event_link}'           => $event['page_url'] ?? '',
+            '{dashboard_profile_url}'  => home_url( '/member-dashboard/?tab=profile', 'relative' ),
+            '{dashboard_upcoming_url}' => home_url( '/member-dashboard/?tab=upcoming', 'relative' ),
+            '{dashboard_past_url}'     => home_url( '/member-dashboard/?tab=past', 'relative' ),
+            '{dashboard_billing_url}'  => home_url( '/member-dashboard/?tab=billing', 'relative' ),
+            '{event_date}'           => $event['date'] ?? '',
+            '{event_time}'           => $event['time'] ?? '',
+            '{event_type}'           => $event['type'] ?? '',
+            '{venue_name}'           => $event['venue_name'] ?? '',
+            '{venue_url}'            => $event['venue_url'] ?? '',
+            '{base_cost}'            => isset( $event['base_cost'] ) ? number_format( (float) $event['base_cost'], 2 ) : '',
+            '{member_cost}'          => isset( $event['member_cost'] ) ? number_format( (float) $event['member_cost'], 2 ) : '',
+            '{premium_cost}'         => isset( $event['premium_cost'] ) ? number_format( (float) $event['premium_cost'], 2 ) : '',
+            '{first_name}'           => $member['first_name'] ?? '',
+            '{last_name}'            => $member['last_name'] ?? '',
+            '{email}'                => $member['user_email'] ?? '',
+            '{phone}'                => $member['member']['phone'] ?? '',
+            '{membership_level}'     => $member['membership_level'] ?? '',
+            '{member_type}'          => $member['member']['member_type'] ?? '',
+        ];
+
+        for ( $i = 0; $i < 4; $i++ ) {
+            $a = $attendees[ $i ] ?? [];
+            $index = $i === 0 ? '' : ( $i + 1 );
+            $tokens[ '{attendee' . $index . '_first_name}' ] = sanitize_text_field( $a['first_name'] ?? '' );
+            $tokens[ '{attendee' . $index . '_last_name}' ]  = sanitize_text_field( $a['last_name'] ?? '' );
+            $tokens[ '{attendee' . $index . '_email}' ]      = sanitize_email( $a['email'] ?? '' );
+            $tokens[ '{attendee' . $index . '_phone}' ]      = sanitize_text_field( $a['phone'] ?? '' );
+        }
+
+        return $tokens;
     }
 }
-?>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1165,6 +1165,71 @@ function tta_get_next_event() {
 }
 
 /**
+ * Retrieve event details for email templates.
+ *
+ * @param string $event_ute_id Event ute_id.
+ * @return array Event data including page_url and costs.
+ */
+function tta_get_event_for_email( $event_ute_id ) {
+    $event_ute_id = sanitize_text_field( $event_ute_id );
+    if ( '' === $event_ute_id ) {
+        return [];
+    }
+
+    $cache_key = 'email_event_' . $event_ute_id;
+    $cached    = TTA_Cache::get( $cache_key );
+    if ( false !== $cached ) {
+        return $cached;
+    }
+
+    global $wpdb;
+    $events_table  = $wpdb->prefix . 'tta_events';
+    $archive_table = $wpdb->prefix . 'tta_events_archive';
+
+    $row = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT id, name, date, time, address, page_id, type, venuename, venueurl, baseeventcost, discountedmembercost, premiummembercost FROM {$events_table} WHERE ute_id = %s",
+            $event_ute_id
+        ),
+        ARRAY_A
+    );
+
+    if ( ! $row ) {
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT id, name, date, time, address, page_id, type, venuename, venueurl, baseeventcost, discountedmembercost, premiummembercost FROM {$archive_table} WHERE ute_id = %s",
+                $event_ute_id
+            ),
+            ARRAY_A
+        );
+    }
+
+    if ( ! $row ) {
+        TTA_Cache::set( $cache_key, [], 60 );
+        return [];
+    }
+
+    $event = [
+        'id'           => intval( $row['id'] ),
+        'name'         => sanitize_text_field( $row['name'] ),
+        'date'         => $row['date'],
+        'time'         => $row['time'],
+        'address'      => tta_format_address( $row['address'] ),
+        'page_id'      => intval( $row['page_id'] ),
+        'page_url'     => get_permalink( intval( $row['page_id'] ) ),
+        'type'         => sanitize_text_field( $row['type'] ),
+        'venue_name'   => sanitize_text_field( $row['venuename'] ),
+        'venue_url'    => esc_url_raw( $row['venueurl'] ),
+        'base_cost'    => floatval( $row['baseeventcost'] ),
+        'member_cost'  => floatval( $row['discountedmembercost'] ),
+        'premium_cost' => floatval( $row['premiummembercost'] ),
+    ];
+
+    TTA_Cache::set( $cache_key, $event, 300 );
+    return $event;
+}
+
+/**
  * Get the remaining ticket count for an upcoming event.
  *
  * @param string $event_ute_id Event ute_id.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1941,7 +1941,7 @@ function tta_get_comm_templates() {
         require_once TTA_PLUGIN_DIR . 'includes/admin/class-comms-admin.php';
     }
     $defaults = TTA_Comms_Admin::get_default_templates();
-    $saved    = get_option( 'tta_comms_templates', [] );
+    $saved    = tta_unslash( get_option( 'tta_comms_templates', [] ) );
 
     if ( is_array( $saved ) ) {
         foreach ( $saved as $k => $vals ) {

--- a/tests/CommsTest.php
+++ b/tests/CommsTest.php
@@ -40,9 +40,9 @@ class CommsTest extends TestCase {
     public function test_ajax_save_template() {
         $_POST = [
             'template_key'      => 'purchase',
-            'email_subject'     => 'New Subj',
-            'email_body'        => 'Body',
-            'sms_text'          => 'SMS',
+            'email_subject'     => 'It\'s New',
+            'email_body'        => 'You\'re invited',
+            'sms_text'          => 'Don\'t forget',
             'tta_comms_save_nonce' => wp_create_nonce('tta_comms_save_action'),
         ];
         // fake WordPress functions
@@ -61,6 +61,22 @@ class CommsTest extends TestCase {
         TTA_Ajax_Comms::save_template();
         $this->assertTrue($GLOBALS['_last_json']['success']);
         $templates = get_option('tta_comms_templates');
-        $this->assertSame('New Subj',$templates['purchase']['email_subject']);
+        $this->assertSame("It's New", $templates['purchase']['email_subject']);
+        $this->assertSame("You're invited", $templates['purchase']['email_body']);
+    }
+
+    public function test_get_comm_templates_unslashes_saved_values() {
+        $stored = [
+            'purchase' => [
+                'email_subject' => 'You\\\'re registered',
+                'email_body'    => 'It\\\'s confirmed',
+                'sms_text'      => ''
+            ]
+        ];
+        update_option('tta_comms_templates', $stored);
+
+        $templates = tta_get_comm_templates();
+        $this->assertSame("You're registered", $templates['purchase']['email_subject']);
+        $this->assertSame("It's confirmed", $templates['purchase']['email_body']);
     }
 }


### PR DESCRIPTION
## Summary
- add AJAX handler to automate sandbox checkout flows
- wire new handler into settings page and asset loader
- implement admin JS to trigger the test suite with spinner
- update debug log docs with info about the test button

## Testing
- `composer install`
- `php vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685dcce76e58832095134b9431fc4cde